### PR TITLE
Feature/seeker-profile

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -8,6 +8,7 @@ import Footer from "./components/layouts/Footer/Footer";
 import Register from "./pages/Forms/Register";
 import Login from "./pages/Forms/Login";
 import { PublicRoute } from "./routes/PublicRoute";
+import ProfilePage from "./pages/UserProfile/ProfilePage";
 
 const App = () => {
   return (
@@ -18,6 +19,8 @@ const App = () => {
           <Route path="/" element={<Body />} />
           <Route path="/user" element={<UserList />} />
           <Route path="/user/create" element={<CreateUser />} />
+
+          <Route path="/profile/*" element={<ProfilePage />} />
 
           <Route
             path="/users/candidate-profile/:id"

--- a/client/src/components/UserPersonalProfile/BaseProfileLayout/BaseProfileLayout.jsx
+++ b/client/src/components/UserPersonalProfile/BaseProfileLayout/BaseProfileLayout.jsx
@@ -1,6 +1,6 @@
-import React from "react";
 import Sidebar from "./Sidebar";
 import styles from "./BaseProfileLayout.module.css";
+import PropTypes from "prop-types";
 
 const BaseProfileLayout = ({ children }) => {
   return (
@@ -11,6 +11,10 @@ const BaseProfileLayout = ({ children }) => {
       <div className={styles.contentWrapper}>{children}</div>
     </div>
   );
+};
+
+BaseProfileLayout.propTypes = {
+  children: PropTypes.node,
 };
 
 export default BaseProfileLayout;

--- a/client/src/components/UserPersonalProfile/BaseProfileLayout/BaseProfileLayout.jsx
+++ b/client/src/components/UserPersonalProfile/BaseProfileLayout/BaseProfileLayout.jsx
@@ -1,0 +1,16 @@
+import React from "react";
+import Sidebar from "./Sidebar";
+import styles from "./BaseProfileLayout.module.css";
+
+const BaseProfileLayout = ({ children }) => {
+  return (
+    <div className={styles.profileLayoutContainer}>
+      <div className={styles.sidebarWrapper}>
+        <Sidebar />
+      </div>
+      <div className={styles.contentWrapper}>{children}</div>
+    </div>
+  );
+};
+
+export default BaseProfileLayout;

--- a/client/src/components/UserPersonalProfile/BaseProfileLayout/BaseProfileLayout.module.css
+++ b/client/src/components/UserPersonalProfile/BaseProfileLayout/BaseProfileLayout.module.css
@@ -1,0 +1,67 @@
+.profileLayoutContainer {
+  display: flex;
+  flex-direction: row;
+  min-height: calc(100vh - var(--navbar-height, 64px));
+}
+
+.sidebarWrapper {
+  min-width: 80px;
+  max-width: 80px;
+  flex-shrink: 0;
+  margin-right: 1.5rem;
+  z-index: 2;
+}
+.contentWrapper {
+  flex: 1 1 0;
+  min-width: 0;
+  background: var(--bg-color, #f8fafc);
+  border-radius: 22px;
+  margin: 2.5rem clamp(1.5rem, 6vw, 2rem);
+  padding: 1.5rem clamp(1.5rem, 6vw, 2rem);
+  box-shadow: 0 2px 12px 0 rgba(60, 72, 88, 0.04);
+  min-height: 80vh;
+  overflow-x: auto;
+  word-break: break-word;
+}
+
+@media (max-width: 1100px) {
+  .sidebarWrapper {
+    margin-right: 0.5rem;
+  }
+  .contentWrapper {
+    margin: 2rem 0.7rem;
+    padding: 1.5rem 0.7rem;
+    border-radius: 16px;
+  }
+}
+
+@media (max-width: 900px) {
+  .sidebarWrapper {
+    margin-right: 0.2rem;
+  }
+  .contentWrapper {
+    margin: 1.2rem 0.3rem;
+    padding: 1rem 0.3rem;
+    border-radius: 12px;
+  }
+}
+
+@media (max-width: 700px) {
+  .profileLayoutContainer {
+    flex-direction: column;
+    min-height: 100vh;
+    padding: 0;
+  }
+  .sidebarWrapper {
+    margin-right: 0;
+    min-width: 100vw;
+    max-width: 100vw;
+    order: 2;
+  }
+  .contentWrapper {
+    margin: 0.7rem 0.1rem 3.5rem 0.1rem;
+    padding: 0.7rem 0.1rem;
+    border-radius: 8px;
+    min-width: 0;
+  }
+}

--- a/client/src/components/UserPersonalProfile/BaseProfileLayout/Sidebar.jsx
+++ b/client/src/components/UserPersonalProfile/BaseProfileLayout/Sidebar.jsx
@@ -1,0 +1,116 @@
+import React from "react";
+import { NavLink, useNavigate } from "react-router-dom";
+import { useUser } from "../../../contexts/UserContext";
+import styles from "./sidebar.module.css";
+import {
+  FaUser,
+  FaBriefcase,
+  FaEnvelope,
+  FaCog,
+  FaSignOutAlt,
+} from "react-icons/fa";
+
+const Sidebar = () => {
+  const { user, logout } = useUser();
+  const navigate = useNavigate();
+  if (!user) return null;
+
+  const handleLogout = async (e) => {
+    e.preventDefault();
+    await logout();
+    navigate("/");
+  };
+
+  return (
+    <nav className={styles.sidebarContainer}>
+      <ul className={styles.navList}>
+        <li className={styles.navItem}>
+          <NavLink
+            to={
+              user.userType === "company"
+                ? "/profile/company-overview"
+                : "/profile/seeker-overview"
+            }
+            className={({ isActive }) =>
+              isActive ? `${styles.navLink} ${styles.active}` : styles.navLink
+            }
+          >
+            <span className={styles.icon}>
+              <FaUser />
+            </span>
+            <span className={styles.label}></span>{" "}
+            {/* we can add texts with icons too */}
+          </NavLink>
+        </li>
+        <li className={styles.navItem}>
+          <NavLink
+            to={
+              user.userType === "company"
+                ? "/profile/projects"
+                : "/profile/seeker-jobs"
+            }
+            className={({ isActive }) =>
+              isActive ? `${styles.navLink} ${styles.active}` : styles.navLink
+            }
+          >
+            <span className={styles.icon}>
+              <FaBriefcase />
+            </span>
+            <span className={styles.label}>
+              {user.userType === "company" ? "" : ""}{" "}
+              {/* we can add texts with icons too  */}
+            </span>
+          </NavLink>
+        </li>
+        <li className={styles.navItem}>
+          <NavLink
+            to="/profile/messages"
+            className={({ isActive }) =>
+              isActive ? `${styles.navLink} ${styles.active}` : styles.navLink
+            }
+          >
+            <span className={styles.icon}>
+              <FaEnvelope />
+            </span>
+            <span className={styles.label}></span>{" "}
+            {/* we can add texts with icons too */}
+          </NavLink>
+        </li>
+        <li className={styles.navItem}>
+          <NavLink
+            to={
+              user.userType === "company"
+                ? "/profile/company-settings"
+                : "/profile/seeker-settings"
+            }
+            className={({ isActive }) =>
+              isActive ? `${styles.navLink} ${styles.active}` : styles.navLink
+            }
+          >
+            <span className={styles.icon}>
+              <FaCog />
+            </span>
+            <span className={styles.label}></span>{" "}
+            {/* we can add texts with icons too */}
+          </NavLink>
+        </li>
+        <li className={styles.navItem}>
+          <a
+            href="#logout"
+            className={styles.navLink}
+            onClick={handleLogout}
+            title="Logout"
+          >
+            <span className={styles.icon}>
+              <FaSignOutAlt />
+            </span>
+            <span className={styles.label}></span>{" "}
+            {/* we can add texts with icons too */}
+          </a>
+        </li>
+      </ul>
+    </nav>
+  );
+};
+
+export default Sidebar;

--- a/client/src/components/UserPersonalProfile/BaseProfileLayout/Sidebar.jsx
+++ b/client/src/components/UserPersonalProfile/BaseProfileLayout/Sidebar.jsx
@@ -45,7 +45,7 @@ const Sidebar = () => {
           <NavLink
             to={
               user.userType === "company"
-                ? "/profile/projects"
+                ? "/profile/company-jobs"
                 : "/profile/seeker-jobs"
             }
             className={({ isActive }) =>

--- a/client/src/components/UserPersonalProfile/BaseProfileLayout/Sidebar.jsx
+++ b/client/src/components/UserPersonalProfile/BaseProfileLayout/Sidebar.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { NavLink, useNavigate } from "react-router-dom";
 import { useUser } from "../../../contexts/UserContext";
 import styles from "./sidebar.module.css";

--- a/client/src/components/UserPersonalProfile/BaseProfileLayout/sidebar.module.css
+++ b/client/src/components/UserPersonalProfile/BaseProfileLayout/sidebar.module.css
@@ -1,0 +1,128 @@
+.sidebarContainer {
+  background: linear-gradient(
+    135deg,
+    #f9fafb 0%,
+    #e0e7ef 40%,
+    #d1d5db 70%,
+    #bfc6e0 85%,
+    #6366f1 100%
+  );
+  width: 80px;
+  min-width: 80px;
+  height: 100vh;
+  border-right: 1.5px solid var(--border-color, #e5e7eb);
+  padding: 2rem 0.5rem 1rem 0.5rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  box-shadow: var(--box-shadow-default, 2px 0 12px rgba(0, 0, 0, 0.06));
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  transition: all 0.2s;
+}
+
+.navList {
+  width: 100%;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+}
+
+.navItem {
+  margin-bottom: 2.2rem;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.navLink {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.3rem;
+  width: 100%;
+  padding: 0.7rem 0;
+  border-radius: var(--default-lg-border-radius, 8px);
+  color: var(--text-secondary-color, #6b7280);
+  font-weight: var(--font-weight-medium, 500);
+  font-size: 1.1rem;
+  text-decoration: none;
+  background: transparent;
+}
+
+.navLink:hover,
+.active {
+  background: var(--hover-color, #eef2ff);
+  color: var(--primary-color, #6366f1);
+  box-shadow: none;
+}
+
+.icon {
+  font-size: 1.4rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--primary-color, #6366f1);
+}
+
+.label {
+  display: inline;
+  transition: opacity 0.2s;
+  font-size: 0.95em;
+}
+
+@media (max-width: 700px) {
+  .sidebarContainer {
+    position: fixed;
+    left: 0;
+    bottom: 0;
+    top: unset;
+    width: 100vw;
+    min-width: 0;
+    height: 60px;
+    background: var(--surface-color, #f9fafb);
+    border-right: none;
+    border-top: 1.5px solid var(--border-color, #e5e7eb);
+    flex-direction: row;
+    align-items: stretch;
+    justify-content: center;
+    padding: 0;
+    box-shadow: 0 -2px 12px rgba(0, 0, 0, 0.06);
+    z-index: 200;
+  }
+  .navList {
+    flex-direction: row;
+    justify-content: space-around;
+    align-items: stretch;
+    width: 100%;
+    height: 100%;
+    margin: 0;
+  }
+  .navItem {
+    flex: 1 1 0;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100%;
+  }
+  .navLink {
+    flex-direction: column;
+    gap: 0.1rem;
+    font-size: 1.1rem;
+    padding: 0;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+    border-radius: 0;
+  }
+  .label {
+    display: none;
+  }
+}

--- a/client/src/components/UserPersonalProfile/Company/Jobs.jsx
+++ b/client/src/components/UserPersonalProfile/Company/Jobs.jsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 const Jobs = () => {
   return <h1>Company Projects</h1>;
 };

--- a/client/src/components/UserPersonalProfile/Company/Jobs.jsx
+++ b/client/src/components/UserPersonalProfile/Company/Jobs.jsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const Jobs = () => {
+  return <h1>Company Projects</h1>;
+};
+
+export default Jobs;

--- a/client/src/components/UserPersonalProfile/Company/Overview.jsx
+++ b/client/src/components/UserPersonalProfile/Company/Overview.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import OverviewHeader from "../Shared/OverviewHeader";
 
 const Overview = () => {

--- a/client/src/components/UserPersonalProfile/Company/Overview.jsx
+++ b/client/src/components/UserPersonalProfile/Company/Overview.jsx
@@ -1,0 +1,13 @@
+import React from "react";
+import OverviewHeader from "../Shared/OverviewHeader";
+
+const Overview = () => {
+  return (
+    <div>
+      <OverviewHeader />
+      <h1>Company Overview</h1>
+    </div>
+  );
+};
+
+export default Overview;

--- a/client/src/components/UserPersonalProfile/Company/Settings.jsx
+++ b/client/src/components/UserPersonalProfile/Company/Settings.jsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const Settings = () => {
+  return <h1>Company Settings</h1>;
+};
+
+export default Settings;

--- a/client/src/components/UserPersonalProfile/Company/Settings.jsx
+++ b/client/src/components/UserPersonalProfile/Company/Settings.jsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 const Settings = () => {
   return <h1>Company Settings</h1>;
 };

--- a/client/src/components/UserPersonalProfile/Seeker/Jobs.jsx
+++ b/client/src/components/UserPersonalProfile/Seeker/Jobs.jsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const Jobs = () => {
+  return <h1>Seeker Jobs</h1>;
+};
+
+export default Jobs;

--- a/client/src/components/UserPersonalProfile/Seeker/Jobs.jsx
+++ b/client/src/components/UserPersonalProfile/Seeker/Jobs.jsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 const Jobs = () => {
   return <h1>Seeker Jobs</h1>;
 };

--- a/client/src/components/UserPersonalProfile/Seeker/Overview.jsx
+++ b/client/src/components/UserPersonalProfile/Seeker/Overview.jsx
@@ -1,0 +1,187 @@
+import React from "react";
+import { useUser } from "../../../contexts/UserContext";
+import OverviewHeader from "../Shared/OverviewHeader";
+import { formatDate } from "../../../util/dates";
+import styles from "./overview-section.module.css";
+import {
+  MdInfo,
+  MdWork,
+  MdSchool,
+  MdLanguage,
+  MdStar,
+  MdSettings,
+  MdLocationOn,
+  MdEmail,
+  MdCloudDownload,
+} from "react-icons/md";
+
+const Section = ({ icon: Icon, title, children }) => (
+  <div className={styles.section}>
+    <div className={styles.sectionHeader}>
+      <Icon className={styles.sectionIcon} />
+      <h2>{title}</h2>
+    </div>
+    <div>{children}</div>
+  </div>
+);
+
+const Overview = () => {
+  const { user } = useUser();
+  if (!user) return null;
+
+  const { email, location, seekerProfile = {} } = user;
+  const {
+    bio,
+    skills,
+    languages,
+    preferences,
+    experiences,
+    education,
+    resumeUrl,
+  } = seekerProfile;
+
+  return (
+    <div className={styles.overviewContainer}>
+      <OverviewHeader />
+
+      {/* Bio/About */}
+      {(bio || location) && (
+        <Section icon={MdInfo} title="About Me">
+          <p>{bio || "No bio to show here."}</p>
+        </Section>
+      )}
+
+      {/* Skills */}
+      {skills && skills.length > 0 ? (
+        <Section icon={MdStar} title="Skills">
+          <ul className={styles.chipList}>
+            {skills.map((skill, i) => (
+              <li key={i} className={styles.chip}>
+                {skill}
+              </li>
+            ))}
+          </ul>
+        </Section>
+      ) : (
+        <Section icon={MdStar} title="Skills">
+          <span className={styles.emptyText}>No skills to show here.</span>
+        </Section>
+      )}
+
+      {/* Languages */}
+      {languages && languages.length > 0 ? (
+        <Section icon={MdLanguage} title="Languages">
+          <ul className={styles.chipList}>
+            {languages.map((lang, i) => (
+              <li key={i} className={styles.chip}>
+                {lang}
+              </li>
+            ))}
+          </ul>
+        </Section>
+      ) : (
+        <Section icon={MdLanguage} title="Languages">
+          <span className={styles.emptyText}>No languages to show here.</span>
+        </Section>
+      )}
+
+      {/* Preferences */}
+      {preferences && preferences.length > 0 ? (
+        <Section icon={MdSettings} title="Preferences">
+          <ul className={styles.chipList}>
+            {preferences.map((pref, i) => (
+              <li key={i} className={styles.chip}>
+                {pref}
+              </li>
+            ))}
+          </ul>
+        </Section>
+      ) : (
+        <Section icon={MdSettings} title="Preferences">
+          <span className={styles.emptyText}>No preferences to show here.</span>
+        </Section>
+      )}
+
+      {/* Experience */}
+      {experiences && experiences.length > 0 ? (
+        <Section icon={MdWork} title="Experience">
+          <ul className={styles.timeline}>
+            {experiences.map((exp, i) => (
+              <li key={i} className={styles.timelineItem}>
+                <div className={styles.timelineTitle}>
+                  <strong>{exp.title}</strong> @ {exp.company}
+                </div>
+                <div className={styles.timelineMeta}>
+                  <MdLocationOn className={styles.inlineIcon} />
+                  {exp.workLocation} &nbsp;|&nbsp;
+                  {formatDate(exp.startDate)} -{" "}
+                  {exp.endDate ? formatDate(exp.endDate) : "Present"}
+                </div>
+                <div className={styles.timelineDesc}>{exp.description}</div>
+              </li>
+            ))}
+          </ul>
+        </Section>
+      ) : (
+        <Section icon={MdWork} title="Experience">
+          <span className={styles.emptyText}>No experience to show here.</span>
+        </Section>
+      )}
+
+      {/* Education */}
+      {education && education.length > 0 ? (
+        <Section icon={MdSchool} title="Education">
+          <ul className={styles.timeline}>
+            {education.map((edu, i) => (
+              <li key={i} className={styles.timelineItem}>
+                <div className={styles.timelineTitle}>
+                  <strong>{edu.degree}</strong> in {edu.fieldOfStudy}
+                </div>
+                <div className={styles.timelineMeta}>
+                  {edu.school} &nbsp;|&nbsp;
+                  <MdLocationOn className={styles.inlineIcon} />
+                  {edu.educationLocation} &nbsp;|&nbsp;
+                  {formatDate(edu.startDate)} -{" "}
+                  {edu.endDate ? formatDate(edu.endDate) : "Present"}
+                </div>
+              </li>
+            ))}
+          </ul>
+        </Section>
+      ) : (
+        <Section icon={MdSchool} title="Education">
+          <span className={styles.emptyText}>No education to show here.</span>
+        </Section>
+      )}
+
+      {/* Contact & Resume */}
+      <Section icon={MdEmail} title="Contact">
+        <div className={styles.contactInfo}>
+          <span className={styles.contactInfoItem}>
+            <MdEmail className={styles.inlineIcon} />
+            {email}
+          </span>
+          {location && (
+            <span className={styles.contactInfoItem}>
+              <MdLocationOn className={styles.inlineIcon} />
+              {location}
+            </span>
+          )}
+          {resumeUrl && (
+            <a
+              href={resumeUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={styles.contactInfoItem}
+            >
+              <MdCloudDownload className={styles.inlineIcon} />
+              Resume
+            </a>
+          )}
+        </div>
+      </Section>
+    </div>
+  );
+};
+
+export default Overview;

--- a/client/src/components/UserPersonalProfile/Seeker/Overview.jsx
+++ b/client/src/components/UserPersonalProfile/Seeker/Overview.jsx
@@ -1,8 +1,9 @@
-import React from "react";
 import { useUser } from "../../../contexts/UserContext";
 import OverviewHeader from "../Shared/OverviewHeader";
 import { formatDate } from "../../../util/dates";
 import styles from "./overview-section.module.css";
+import PropTypes from "prop-types";
+
 import {
   MdInfo,
   MdWork,
@@ -185,3 +186,9 @@ const Overview = () => {
 };
 
 export default Overview;
+
+Section.propTypes = {
+  icon: PropTypes.elementType.isRequired,
+  title: PropTypes.string.isRequired,
+  children: PropTypes.node,
+};

--- a/client/src/components/UserPersonalProfile/Seeker/Settings.jsx
+++ b/client/src/components/UserPersonalProfile/Seeker/Settings.jsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const Settings = () => {
+  return <h1>Seeker Settings</h1>;
+};
+
+export default Settings;

--- a/client/src/components/UserPersonalProfile/Seeker/Settings.jsx
+++ b/client/src/components/UserPersonalProfile/Seeker/Settings.jsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 const Settings = () => {
   return <h1>Seeker Settings</h1>;
 };

--- a/client/src/components/UserPersonalProfile/Seeker/overview-section.module.css
+++ b/client/src/components/UserPersonalProfile/Seeker/overview-section.module.css
@@ -1,0 +1,218 @@
+.section {
+  background: var(--surface-color, #fff);
+  border-radius: 18px;
+  box-shadow: 0 2px 18px 0 rgba(60, 72, 88, 0.08);
+  padding: 2rem;
+  margin-bottom: 2rem;
+  border: 1px solid var(--border-color, #e5e7eb);
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+  word-break: break-word;
+  overflow-wrap: anywhere;
+  font-family: var(--text-font-family, "Outfit", sans-serif);
+}
+
+.sectionHeader {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 0.7rem;
+}
+
+.sectionIcon {
+  font-size: 1.5rem;
+  color: var(--primary-color, #6366f1);
+  background: #eef2ff;
+  border-radius: 50%;
+  padding: 0.25em;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2rem;
+  min-height: 2rem;
+  box-shadow: 0 1px 4px rgba(99, 102, 241, 0.06);
+}
+
+.section h2 {
+  font-size: 1.18rem;
+  font-weight: var(--font-weight-bold, 700);
+  color: var(--heading-color, #232946);
+  margin: 0;
+  letter-spacing: 0.01em;
+  line-height: 1.1;
+  display: flex;
+  align-items: center;
+  font-family: var(--heading-font-family, "Poppins", sans-serif);
+}
+
+.chipList {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.7rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.chip {
+  background: #eef2ff;
+  color: var(--primary-color, #6366f1);
+  border-radius: 999px;
+  padding: 0.35em 1em;
+  font-weight: 500;
+  font-size: 0.98rem;
+  box-shadow: 0 1px 4px rgba(99, 102, 241, 0.04);
+  margin-bottom: 0.2em;
+  font-family: var(--text-font-family, "Outfit", sans-serif);
+}
+
+.timeline {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.timelineItem {
+  margin-bottom: 1.1em;
+  padding-bottom: 1em;
+  border-left: 2px solid var(--primary-color, #6366f1);
+  padding-left: 1em;
+  position: relative;
+}
+
+.timelineTitle {
+  font-weight: 600;
+  color: var(--heading-color, #232946);
+  margin-bottom: 0.15em;
+  font-family: var(--heading-font-family, "Poppins", sans-serif);
+}
+
+.timelineMeta {
+  font-size: 0.97em;
+  color: var(--success-color, #22c55e);
+  margin-bottom: 0.3em;
+  display: flex;
+  align-items: center;
+  gap: 0.3em;
+  font-weight: 500;
+}
+
+.timelineDesc {
+  color: var(--text-secondary-color, #444);
+  font-size: 0.97em;
+  margin-top: 0.15em;
+}
+
+.inlineInfo {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4em;
+  color: var(--primary-color, #6366f1);
+  font-size: 0.98em;
+  background: #eef2ff;
+  border-radius: 999px;
+  padding: 0.25em 0.9em;
+  margin-top: 0.5em;
+  font-weight: 500;
+  text-decoration: none;
+  width: fit-content;
+  box-shadow: none;
+}
+
+.inlineIcon {
+  font-size: 1.1em;
+}
+
+.emptyText {
+  color: var(--text-secondary-color, #aaa);
+  font-style: italic;
+  font-size: 0.98em;
+  margin-top: 0.4em;
+  display: block;
+}
+
+.contactInfo {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.7rem;
+  margin-top: 0.7rem;
+  background: none;
+  padding: 0;
+  border-radius: 0;
+  max-width: 100%;
+}
+
+.contactInfoItem {
+  display: flex;
+  align-items: center;
+  gap: 0.5em;
+  color: var(--primary-color, #6366f1);
+  font-weight: 500;
+  font-size: 0.98rem;
+  background: #eef2ff;
+  border-radius: 999px;
+  padding: 0.35em 1em;
+  box-shadow: 0 1px 4px rgba(99, 102, 241, 0.04);
+  text-decoration: none;
+  margin-bottom: 0.2em;
+}
+
+.contactInfoItem:hover {
+  background: var(--primary-color, #6366f1);
+  color: #fff;
+}
+
+.timelineMeta,
+.timelineDesc,
+.emptyText,
+.contactInfoItem {
+  font-family: var(--text-font-family, "Outfit", sans-serif);
+}
+
+@media (max-width: 900px) {
+  .section {
+    padding: 1.2rem 0.7rem;
+    border-radius: 14px;
+    margin-bottom: 1.2rem;
+  }
+  .sectionHeader {
+    gap: 0.7rem;
+    margin-bottom: 0.7rem;
+  }
+  .sectionIcon {
+    font-size: 1.2rem;
+    padding: 0.18em;
+    min-width: 1.2rem;
+    min-height: 1.2rem;
+  }
+}
+
+@media (max-width: 600px) {
+  .section {
+    padding: 1rem 0.7rem;
+    border-radius: 10px;
+    margin-bottom: 1rem;
+  }
+  .sectionHeader {
+    gap: 0.4rem;
+    margin-bottom: 0.5rem;
+  }
+  .sectionIcon {
+    font-size: 1rem;
+    padding: 0.08em;
+    min-width: 1rem;
+    min-height: 1rem;
+  }
+  .chip {
+    font-size: 0.93rem;
+    padding: 0.22em 0.7em;
+  }
+  .contactInfo {
+    gap: 0.5rem;
+  }
+  .contactInfoItem {
+    font-size: 0.93rem;
+    padding: 0.22em 0.7em;
+  }
+}

--- a/client/src/components/UserPersonalProfile/Shared/Messages.jsx
+++ b/client/src/components/UserPersonalProfile/Shared/Messages.jsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const Messages = () => {
+  return <h1>Messages</h1>;
+};
+
+export default Messages;

--- a/client/src/components/UserPersonalProfile/Shared/Messages.jsx
+++ b/client/src/components/UserPersonalProfile/Shared/Messages.jsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 const Messages = () => {
   return <h1>Messages</h1>;
 };

--- a/client/src/components/UserPersonalProfile/Shared/OverviewHeader.jsx
+++ b/client/src/components/UserPersonalProfile/Shared/OverviewHeader.jsx
@@ -1,0 +1,83 @@
+import React from "react";
+import { MdEmail, MdLocationOn } from "react-icons/md";
+import { useUser } from "../../../contexts/UserContext";
+import { useNavigate } from "react-router-dom";
+import styles from "./header-section.module.css";
+import Avatar from "../../../../src/assets/woman.png";
+
+const OverviewHeader = () => {
+  const { user } = useUser();
+  const navigate = useNavigate();
+  if (!user) return null;
+
+  const { userType, email, profilePhoto, location } = user;
+
+  // Seeker fields
+  const seekerProfile = user.seekerProfile || {};
+  const { firstName, lastName, position } = seekerProfile;
+
+  // Company fields
+  const companyProfile = user.companyProfile || {};
+  const { companyName, industry } = companyProfile;
+
+  //  display values
+  const displayName =
+    userType === "company"
+      ? companyName
+      : [firstName, lastName].filter(Boolean).join(" ");
+  const displayRole = userType === "company" ? industry : position;
+
+  //   Edit button
+  const handleEditClick = () => {
+    if (userType === "company") {
+      navigate("/profile/company-settings");
+    } else {
+      navigate("/profile/seeker-settings");
+    }
+  };
+
+  return (
+    <div className={styles.headerWrapper}>
+      <div className={styles.leftSection}>
+        <div className={styles.profileImageWrapper}>
+          <img
+            className={styles.profileImage}
+            src={profilePhoto || Avatar}
+            alt={`${displayName}`}
+          />
+        </div>
+        <div className={styles.profileDetails}>
+          <div className={styles.nameRoleWrapper}>
+            <h2 className={styles.profileName}>{displayName}</h2>
+            {displayRole && (
+              <span className={styles.roleBadge}>{displayRole}</span>
+            )}
+          </div>
+          <div className={styles.contactDetails}>
+            <p className={styles.profileItem}>
+              <MdEmail className={styles.icon} />
+              {email}
+            </p>
+            {location && (
+              <p className={styles.profileItem}>
+                <MdLocationOn className={styles.icon} />
+                {location}
+              </p>
+            )}
+          </div>
+        </div>
+      </div>
+      <div className={styles.rightSection}>
+        <button
+          id="contactBtnId"
+          className="btn btn-primary"
+          onClick={handleEditClick}
+        >
+          Edit
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default OverviewHeader;

--- a/client/src/components/UserPersonalProfile/Shared/OverviewHeader.jsx
+++ b/client/src/components/UserPersonalProfile/Shared/OverviewHeader.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { MdEmail, MdLocationOn } from "react-icons/md";
 import { useUser } from "../../../contexts/UserContext";
 import { useNavigate } from "react-router-dom";

--- a/client/src/components/UserPersonalProfile/Shared/header-section.module.css
+++ b/client/src/components/UserPersonalProfile/Shared/header-section.module.css
@@ -1,0 +1,235 @@
+.headerWrapper {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 2.5rem;
+  padding: 2.5rem 3rem 2.5rem 3rem;
+  background: var(--surface-color, #fff);
+  border-radius: 20px;
+  box-shadow: 0 2px 18px 0 rgba(60, 72, 88, 0.08);
+  margin-top: 2rem;
+  margin-bottom: 2rem;
+  position: relative;
+  flex-wrap: wrap;
+  min-height: 180px;
+}
+
+.leftSection {
+  display: flex;
+  gap: 2.2rem;
+  align-items: center;
+  flex: 1;
+  min-width: 0;
+}
+
+.profileImageWrapper {
+  flex-shrink: 0;
+  width: 140px;
+  height: 140px;
+  border-radius: 50%;
+  overflow: hidden;
+  border: 3px solid var(--border-color, #e5e7eb);
+  box-shadow: 0 2px 12px rgba(99, 102, 241, 0.08);
+  background: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.profileImage {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 50%;
+  display: block;
+}
+
+.profileDetails {
+  flex: 1;
+  min-width: 0;
+}
+
+.nameRoleWrapper {
+  display: flex;
+  align-items: center;
+  gap: 1.3rem;
+  margin-bottom: 1.2rem;
+  flex-wrap: wrap;
+}
+
+.profileName {
+  font-family: var(--heading-font-family, "Inter", sans-serif);
+  font-size: 2.2rem;
+  font-weight: var(--font-weight-bold, 700);
+  color: var(--heading-color, #232946);
+  margin: 0;
+  line-height: 1.1;
+  letter-spacing: -0.5px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.roleBadge {
+  background-color: var(--accent-color);
+  color: var(--btn-text-color, #fff);
+  padding: 0.5rem 1rem;
+  border-radius: var(--default-xxl-border-radius);
+  font-size: 0.9rem;
+  font-weight: var(--font-weight-semibold, 600);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  box-shadow: 0 1px 4px rgba(99, 102, 241, 0.08);
+}
+
+.contactDetails {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  align-items: center;
+  margin-top: 0.7rem;
+}
+
+.profileItem {
+  display: flex;
+  align-items: center;
+  gap: 0.5em;
+  color: var(--primary-color, #6366f1);
+  font-size: 1.05rem;
+  background: #eef2ff;
+  padding: 0.28em 1.1em;
+  border-radius: 999px;
+  font-weight: 500;
+  white-space: nowrap;
+  box-shadow: 0 1px 4px rgba(99, 102, 241, 0.06);
+}
+
+.icon {
+  color: var(--primary-color, #6366f1);
+  font-size: 1.2rem;
+}
+
+.rightSection {
+  display: flex;
+  gap: 1.2rem;
+  align-items: flex-end;
+  flex-shrink: 0;
+  position: absolute;
+  bottom: 2.5rem;
+  right: 3rem;
+}
+
+.btn {
+  font-size: 1.05rem;
+  font-weight: 600;
+  padding: 0.7em 1.7em;
+  border-radius: 8px;
+  border: none;
+  cursor: pointer;
+  transition:
+    background 0.18s,
+    color 0.18s,
+    box-shadow 0.18s;
+  box-shadow: 0 1px 4px rgba(99, 102, 241, 0.08);
+}
+
+.btn-primary {
+  background: var(--primary-color, #6366f1);
+  color: #fff;
+  border: none;
+}
+
+.btn-primary:hover {
+  background: #4f46e5;
+}
+
+.btn-outline {
+  background: #fff;
+  color: var(--primary-color, #6366f1);
+  border: 2px solid var(--primary-color, #6366f1);
+}
+
+.btn-outline:hover {
+  background: #eef2ff;
+  color: #4f46e5;
+}
+
+@media (max-width: 1100px) {
+  .headerWrapper {
+    padding: 1.5rem 1.2rem;
+    min-height: 120px;
+  }
+  .profileImageWrapper {
+    width: 100px;
+    height: 100px;
+  }
+  .profileName {
+    font-size: 1.5rem;
+  }
+  .rightSection {
+    bottom: 1.5rem;
+    right: 1.2rem;
+  }
+}
+
+@media (max-width: 768px) {
+  .headerWrapper {
+    flex-direction: column;
+    align-items: center;
+    gap: 1.2rem;
+    padding: 1.2rem 0.7rem;
+    min-height: unset;
+    position: static;
+  }
+
+  .leftSection {
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    gap: 1rem;
+    width: 100%;
+  }
+
+  .profileImageWrapper {
+    width: 80px;
+    height: 80px;
+  }
+
+  .nameRoleWrapper {
+    flex-direction: column;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0.7rem;
+  }
+
+  .profileName {
+    font-size: 1.1rem;
+  }
+
+  .roleBadge {
+    font-size: 0.65rem;
+    padding: 0.13rem 0.6rem;
+  }
+
+  .contactDetails {
+    flex-direction: column;
+    gap: 0.4rem;
+    margin-top: 0.5rem;
+    align-items: center;
+  }
+
+  .rightSection {
+    position: static;
+    margin: 1rem 0 0 0;
+    justify-content: center;
+    align-items: center;
+    flex-direction: row;
+    gap: 0.7rem;
+    width: 100%;
+  }
+
+  #contactBtnId,
+  #downloadBtnId {
+    width: 100%;
+  }
+}

--- a/client/src/components/layouts/Navbar/Navbar.jsx
+++ b/client/src/components/layouts/Navbar/Navbar.jsx
@@ -1,7 +1,10 @@
 import { NavLink } from "react-router-dom";
 import styles from "./navbar.module.css";
+import { useUser } from "../../../contexts/UserContext";
+import { MdPerson } from "react-icons/md";
 
 const Navbar = () => {
+  const { user } = useUser();
   return (
     <header>
       <nav className={styles.navbar}>
@@ -21,23 +24,33 @@ const Navbar = () => {
             </NavLink>
           </li>
         </ul>
-
         <div className={styles.authActions}>
-          <NavLink
-            to="/login"
-            className={({ isActive }) =>
-              isActive ? `${styles.navLink} ${styles.active}` : styles.navLink
-            }
-          >
-            Login
-          </NavLink>
-          <NavLink
-            to="/register"
-            className="btn btn-primary"
-            style={{ padding: "0.4rem .9rem" }}
-          >
-            Sign Up
-          </NavLink>
+          {/* if a user is logged in (later we create better), show profile icon; otherwise, show login and signup links */}
+          {!user ? (
+            <>
+              <NavLink
+                to="/login"
+                className={({ isActive }) =>
+                  isActive
+                    ? `${styles.navLink} ${styles.active}`
+                    : styles.navLink
+                }
+              >
+                Login
+              </NavLink>
+              <NavLink
+                to="/register"
+                className="btn btn-primary"
+                style={{ padding: "0.4rem .9rem" }}
+              >
+                Sign Up
+              </NavLink>
+            </>
+          ) : (
+            <NavLink to="/profile" className={styles.navLink}>
+              <MdPerson className={styles.profileIcon} size={40} />
+            </NavLink>
+          )}
         </div>
       </nav>
     </header>

--- a/client/src/components/layouts/Navbar/navbar.module.css
+++ b/client/src/components/layouts/Navbar/navbar.module.css
@@ -1,6 +1,8 @@
-header {
+/*  Commented the margin-bottom for header to avoid extra space */
+
+/* header {
   margin-bottom: 4rem;
-}
+} */
 
 .navbar {
   display: flex;
@@ -10,7 +12,7 @@ header {
   background: var(--bg-color);
   font-family: var(--text-font-family);
   border-bottom: 1px solid var(--border-color);
-  height: 60px;
+  height: var(--navbar-height, 65px);
 }
 
 .logo {

--- a/client/src/components/layouts/Navbar/navbar.module.css
+++ b/client/src/components/layouts/Navbar/navbar.module.css
@@ -3,7 +3,22 @@
 /* header {
   margin-bottom: 4rem;
 } */
+.profileIcon {
+  color: var(--primary-color, #6366f1);
+  vertical-align: middle;
+  border-radius: 50%;
+  background: #eef2ff;
+  padding: 4px;
+  transition:
+    background 0.15s,
+    color 0.15s;
+}
 
+.profileIcon:hover,
+.navLink.active .profileIcon {
+  background: var(--primary-color, #6366f1);
+  color: #fff;
+}
 .navbar {
   display: flex;
   justify-content: space-between;

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -54,6 +54,9 @@
   /* Box shadows */
   --box-shadow-default: 0 1px 3px var(--default-shadow-color);
   --box-shadow-md: 0 4px 6px var(--default-shadow-color);
+
+  /* Navbar height */
+  --navbar-height: 60px;
 }
 
 /* Applies universal reset  */

--- a/client/src/pages/UserProfile/ProfilePage.jsx
+++ b/client/src/pages/UserProfile/ProfilePage.jsx
@@ -1,0 +1,52 @@
+import React from "react";
+import { Routes, Route } from "react-router-dom";
+import { useUser } from "../../contexts/UserContext";
+import BaseProfileLayout from "../../components/UserPersonalProfile/BaseProfileLayout/BaseProfileLayout";
+
+//  Seeker-specific components
+import SeekerOverview from "../../components/UserPersonalProfile/Seeker/Overview";
+import SeekerJobs from "../../components/UserPersonalProfile/Seeker/Jobs";
+import SeekerSettings from "../../components/UserPersonalProfile/Seeker/Settings";
+
+//  Company-specific components
+import CompanyOverview from "../../components/UserPersonalProfile/Company/Overview";
+import CompanyJobs from "../../components/UserPersonalProfile/Company/Jobs";
+import CompanySettings from "../../components/UserPersonalProfile/Company/Settings";
+
+//   shared
+import Messages from "../../components/UserPersonalProfile/Shared/Messages";
+
+const ProfilePage = () => {
+  const { user, loading } = useUser();
+  if (loading) return <div>Loading...</div>; //  spinner later
+  if (!user) return <div>No user found.</div>; //  handle no user case we will add a redirect later
+
+  return (
+    <BaseProfileLayout>
+      <Routes>
+        {/*  route for messages */}
+        <Route path="messages" element={<Messages />} />
+        {/*  Conditional routes based on user type */}
+        {user.userType === "seeker" ? (
+          <>
+            <Route path="seeker-overview" element={<SeekerOverview />} />
+            <Route path="seeker-jobs" element={<SeekerJobs />} />
+            <Route path="seeker-settings" element={<SeekerSettings />} />
+            {/* Default  */}
+            <Route index element={<SeekerOverview />} />
+          </>
+        ) : (
+          <>
+            <Route path="company-overview" element={<CompanyOverview />} />
+            <Route path="company-jobs" element={<CompanyJobs />} />
+            <Route path="company-settings" element={<CompanySettings />} />
+            {/* Default  */}
+            <Route index element={<CompanyOverview />} />
+          </>
+        )}
+      </Routes>
+    </BaseProfileLayout>
+  );
+};
+
+export default ProfilePage;

--- a/client/src/pages/UserProfile/ProfilePage.jsx
+++ b/client/src/pages/UserProfile/ProfilePage.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Routes, Route } from "react-router-dom";
 import { useUser } from "../../contexts/UserContext";
 import BaseProfileLayout from "../../components/UserPersonalProfile/BaseProfileLayout/BaseProfileLayout";


### PR DESCRIPTION
**Sorry for all these files but most of them are empty with just h1 to test the routes**

Created personal profiles file structures, and routes, using one layout for all the profiles and switching between the content according to the user type and the navigated components via the sidebar. 

Created the overview page for the Seeker-Personal profile, the page gets its data from the logged-in user via the user context hook. 

Created a header for the overview that accommodates to the user type.

Finally, I did not use components for the overview section due to the need for logic to customize the components and the icons, I decided to centralize it and pass the data to it, also, there will be adjustments for the design.

You can test it via this user : 
LOGIN
email: jane.doe@example.com
password : 12345678


Seeker Profile overview with data : 

<img width="1462" alt="Screenshot 2025-05-27 at 22 48 09" src="https://github.com/user-attachments/assets/6b52754c-a1e0-4597-9644-ebf2cb9f9e8a" />

<img width="1437" alt="Screenshot 2025-05-27 at 22 48 26" src="https://github.com/user-attachments/assets/7638b5ab-af56-4c34-ae5a-bb73fa77fc1f" />

<img width="342" alt="Screenshot 2025-05-27 at 22 48 59" src="https://github.com/user-attachments/assets/ea59c05d-e5df-426a-be31-2cad9bbd49c2" />


No data case : 

<img width="1439" alt="Screenshot 2025-05-27 at 22 50 25" src="https://github.com/user-attachments/assets/d71efd09-6ab5-4bc9-a9f1-e46cc520e9eb" />





