### PR TITLE
Add job recommendations based on recent viewed job post and profile b…

### DIFF
--- a/server/src/controllers/jobPost.js
+++ b/server/src/controllers/jobPost.js
@@ -1,8 +1,11 @@
 import { User } from "../models/User.js";
 import JobPost from "../models/JobPost.js";
-import { MAX_POSTS_PER_DAY } from "../constants.js";
+
 import { endOfToday, startOfToday } from "../util/utils.js";
-import { populateJobsWithCompany } from "../helpers/jobPostHelper.js";
+import { findJobs } from "../helpers/jobPostHelper.js";
+import { escapeRegex } from "../util/utils.js";
+
+import { MAX_POSTS_PER_DAY } from "../constants.js";
 
 /**
  * Create a new job post.
@@ -114,16 +117,48 @@ export const updateJob = async (req, res) => {
 };
 
 /**
- *  Get all job posts along with specific company info (company name and logo)
+ *  Get all job posts based on a given criteria or key which is {} by default.
+ *
+ *  If we provide page number and limit it will find all jobs by skipping (page-1)*limit.
  */
 
 export const jobs = async (req, res) => {
-  const jobPosts = await JobPost.find();
-  if (!jobPosts.length) {
-    return res.status(404).json({ success: false, msg: "No job posts found." });
+  const { location, title, tags, page = 1, limit = 10 } = req.query;
+
+  const criteria = {};
+
+  if (location) {
+    const safeLocation = escapeRegex(location);
+    criteria.location = { $regex: safeLocation, $options: "i" };
   }
 
-  const jobs = populateJobsWithCompany(jobPosts);
+  if (title) {
+    const safeTitle = escapeRegex(title);
+    criteria.title = { $regex: safeTitle, $options: "i" };
+  }
 
-  return res.status(200).json({ success: true, data: jobs });
+  if (tags) {
+    const tagList = tags.split(",").map((tag) => tag.trim());
+    criteria.tags = {
+      $elemMatch: {
+        $in: tagList.map((tag) => new RegExp(`^${escapeRegex(tag)}$`, "i")),
+      },
+    };
+  }
+
+  const pageNumber = Math.max(1, parseInt(page));
+  const limitNumber = Math.max(1, parseInt(limit));
+
+  const skip = (pageNumber - 1) * limitNumber;
+
+  const jobs = await findJobs(
+    criteria,
+    "title tags location description createdAt",
+    true,
+    { createdAt: -1 },
+    skip,
+    limitNumber,
+  );
+
+  res.status(200).json({ success: true, data: jobs });
 };

--- a/server/src/controllers/jobPost.js
+++ b/server/src/controllers/jobPost.js
@@ -2,6 +2,7 @@ import { User } from "../models/User.js";
 import JobPost from "../models/JobPost.js";
 import { MAX_POSTS_PER_DAY } from "../constants.js";
 import { endOfToday, startOfToday } from "../util/utils.js";
+import { populateJobsWithCompany } from "../helpers/jobPostHelper.js";
 
 /**
  * Create a new job post.
@@ -122,19 +123,7 @@ export const jobs = async (req, res) => {
     return res.status(404).json({ success: false, msg: "No job posts found." });
   }
 
-  const jobs = await Promise.all(
-    jobPosts.map(async (jobPost) => {
-      const company = await User.findById(jobPost.postedBy)
-        .select("companyProfile.companyName profilePhoto")
-        .lean();
-
-      return {
-        ...jobPost.toObject(),
-        companyName: company?.companyProfile?.companyName || null,
-        profilePhoto: company?.profilePhoto,
-      };
-    }),
-  );
+  const jobs = populateJobsWithCompany(jobPosts);
 
   return res.status(200).json({ success: true, data: jobs });
 };

--- a/server/src/controllers/jobPost.js
+++ b/server/src/controllers/jobPost.js
@@ -117,9 +117,11 @@ export const updateJob = async (req, res) => {
 };
 
 /**
- *  Get all job posts based on a given criteria or key which is {} by default.
+ *  Get all job posts along company inf based on a given
+ *  criteria or key which is {} by default.
  *
- *  If we provide page number and limit it will find all jobs by skipping (page-1)*limit.
+ *  If we provide page number and limit it will find all
+ *  jobs by skipping (page-1)*limit.
  */
 
 export const jobs = async (req, res) => {
@@ -154,11 +156,11 @@ export const jobs = async (req, res) => {
   const jobs = await findJobs(
     criteria,
     "title tags location description createdAt",
-    true,
+    "postedBy",
     { createdAt: -1 },
     skip,
     limitNumber,
   );
 
-  res.status(200).json({ success: true, data: jobs });
+  return res.status(200).json({ success: true, data: jobs });
 };

--- a/server/src/controllers/jobRecommendations.js
+++ b/server/src/controllers/jobRecommendations.js
@@ -1,9 +1,4 @@
-import {
-  populateJobsWithCompany,
-  recommendByCriteria,
-} from "../helpers/jobPostHelper.js";
-import JobPost from "../models/JobPost.js";
-
+import { findJobs, recommendByCriteria } from "../helpers/jobPostHelper.js";
 import { profileBasedMatchingCriterion } from "../util/jobMatching/profileBased.js";
 import { recentViewMatchingCriterion } from "../util/jobMatching/recentViewed.js";
 
@@ -11,15 +6,29 @@ import { recentViewMatchingCriterion } from "../util/jobMatching/recentViewed.js
  * Job recommendations based on recently clicked and view job post by a user
  */
 export const recommendationsByRecentView = async (req, res) => {
+  const fallbackQuery = () =>
+    findJobs(
+      { _id: { $ne: req.jobPost._id } },
+      "title tags location description",
+      "postedBy",
+      { createdAt: -1 },
+      0,
+      10,
+    );
+
   const response = await recommendByCriteria(
     recentViewMatchingCriterion,
     req.jobPost,
     "recent-view-based",
-    () => JobPost.find().sort({ createdAt: -1 }).limit(5),
+    fallbackQuery,
   );
 
-  if (response.success) {
-    response.data = await populateJobsWithCompany(response.data);
+  if (!response.success) {
+    return {
+      success: false,
+      status: 500,
+      msg: "Failed to get recommendations.",
+    };
   }
 
   return res.status(200).json(response);
@@ -30,15 +39,37 @@ export const recommendationsByRecentView = async (req, res) => {
  * example: preference, skills, position and location
  */
 export const recommendationsByProfile = async (req, res) => {
+  const matches = profileBasedMatchingCriterion(req.fullUser);
+
+  if (!matches.length) {
+    return res.status(400).json({
+      success: false,
+      message: "Job seeker must complete profile first.",
+    });
+  }
+
+  const fallbackQuery = () =>
+    findJobs(
+      {},
+      "title tags location description",
+      "postedBy",
+      { createdAt: -1 },
+      0,
+      10,
+    );
+
   const response = await recommendByCriteria(
     profileBasedMatchingCriterion,
     req.fullUser,
     "profile-based",
-    () => JobPost.find().sort({ createdAt: -1 }).limit(10),
+    fallbackQuery,
   );
 
-  if (response.success) {
-    response.data = await populateJobsWithCompany(response.data);
+  if (!response.success) {
+    return res.status(500).json({
+      success: false,
+      message: "Failed to get recommendations.",
+    });
   }
 
   return res.status(200).json(response);

--- a/server/src/controllers/jobRecommendations.js
+++ b/server/src/controllers/jobRecommendations.js
@@ -39,14 +39,9 @@ export const recommendationsByRecentView = async (req, res) => {
  * example: preference, skills, position and location
  */
 export const recommendationsByProfile = async (req, res) => {
-  const matches = profileBasedMatchingCriterion(req.fullUser);
+  const user = req.fullUser;
 
-  if (!matches.length) {
-    return res.status(400).json({
-      success: false,
-      message: "Job seeker must complete profile first.",
-    });
-  }
+  const criteria = profileBasedMatchingCriterion(user);
 
   const fallbackQuery = () =>
     findJobs(
@@ -58,9 +53,22 @@ export const recommendationsByProfile = async (req, res) => {
       10,
     );
 
+  // If user profile is incomplete, fallback but still remind them to complete their profile.
+  if (!criteria.length) {
+    const fallback = await fallbackQuery();
+
+    return res.status(200).json({
+      success: true,
+      message:
+        "Showing recent jobs. Complete your profile to get better recommendations.",
+      data: fallback,
+      personalized: false,
+    });
+  }
+
   const response = await recommendByCriteria(
-    profileBasedMatchingCriterion,
-    req.fullUser,
+    () => criteria,
+    user,
     "profile-based",
     fallbackQuery,
   );
@@ -72,5 +80,7 @@ export const recommendationsByProfile = async (req, res) => {
     });
   }
 
-  return res.status(200).json(response);
+  return res.status(200).json({
+    ...response,
+  });
 };

--- a/server/src/controllers/jobRecommendations.js
+++ b/server/src/controllers/jobRecommendations.js
@@ -1,0 +1,45 @@
+import {
+  populateJobsWithCompany,
+  recommendByCriteria,
+} from "../helpers/jobPostHelper.js";
+import JobPost from "../models/JobPost.js";
+
+import { profileBasedMatchingCriterion } from "../util/jobMatching/profileBased.js";
+import { recentViewMatchingCriterion } from "../util/jobMatching/recentViewed.js";
+
+/**
+ * Job recommendations based on recently clicked and view job post by a user
+ */
+export const recommendationsByRecentView = async (req, res) => {
+  const response = await recommendByCriteria(
+    recentViewMatchingCriterion,
+    req.jobPost,
+    "recent-view-based",
+    () => JobPost.find().sort({ createdAt: -1 }).limit(5),
+  );
+
+  if (response.success) {
+    response.data = await populateJobsWithCompany(response.data);
+  }
+
+  return res.status(200).json(response);
+};
+
+/**
+ * Job recommendations based on logged in user's profile
+ * example: preference, skills, position and location
+ */
+export const recommendationsByProfile = async (req, res) => {
+  const response = await recommendByCriteria(
+    profileBasedMatchingCriterion,
+    req.fullUser,
+    "profile-based",
+    () => JobPost.find().sort({ createdAt: -1 }).limit(10),
+  );
+
+  if (response.success) {
+    response.data = await populateJobsWithCompany(response.data);
+  }
+
+  return res.status(200).json(response);
+};

--- a/server/src/helpers/jobPostHelper.js
+++ b/server/src/helpers/jobPostHelper.js
@@ -1,0 +1,68 @@
+import { User } from "../models/User.js";
+import JobPost from "../models/JobPost.js";
+
+/**
+ * Fetches recommended jobs using a tiered matching strategy.
+ *
+ * It always starts by looking for jobs that strictly match all the criteria.
+ * If no results are found, it gradually relaxes the filters; first trying moderate,
+ * then loose criteria.
+ *
+ * If even the loose criteria don’t return any jobs, it falls back to a default query,
+ * like fetching the most recent job posts.
+ *
+ * This approach follows a progression from:
+ * Strict → Moderate → Loose → Fallback
+ *
+ * Further we can add match level to the response.
+ */
+
+export const recommendByCriteria = async (
+  criteriaFn,
+  input,
+  typeLabel,
+  fallbackQuery,
+) => {
+  const criteriaList = criteriaFn(input);
+  let recommendedJobs = [];
+
+  let matchLevel = "";
+  for (const criteria of criteriaList) {
+    matchLevel = criteria.type;
+    recommendedJobs = await JobPost.find(criteria.value).limit(10);
+    if (recommendedJobs.length) break;
+  }
+
+  if (!recommendedJobs.length) {
+    matchLevel = "recent";
+    recommendedJobs = await fallbackQuery();
+  }
+
+  if (!recommendedJobs.length) {
+    return { success: false, status: 404, msg: "No recommendations found." };
+  }
+
+  return {
+    success: true,
+    data: recommendedJobs,
+    type: typeLabel,
+    matchLevel: matchLevel,
+  };
+};
+
+/** Populates job post with company info */
+export const populateJobsWithCompany = async (jobPosts) => {
+  return Promise.all(
+    jobPosts.map(async (jobPost) => {
+      const company = await User.findById(jobPost.postedBy)
+        .select("companyProfile.companyName profilePhoto")
+        .lean();
+
+      return {
+        ...jobPost.toObject(),
+        companyName: company?.companyProfile?.companyName || null,
+        profilePhoto: company?.profilePhoto,
+      };
+    }),
+  );
+};

--- a/server/src/helpers/jobPostHelper.js
+++ b/server/src/helpers/jobPostHelper.js
@@ -20,7 +20,7 @@ import JobPost from "../models/JobPost.js";
 export const findJobs = async (
   criteria = {},
   selectedFields = " ",
-  populateFields = " ",
+  path = null,
   sort = { createdAt: -1 },
   skip = 0,
   limit = 10,
@@ -31,7 +31,7 @@ export const findJobs = async (
     .skip(skip)
     .limit(limit);
 
-  if (populateFields) {
+  if (path) {
     query = query.populate({
       path: "postedBy",
       select: "companyProfile.companyName profilePhoto",

--- a/server/src/helpers/jobPostHelper.js
+++ b/server/src/helpers/jobPostHelper.js
@@ -1,5 +1,45 @@
-import { User } from "../models/User.js";
 import JobPost from "../models/JobPost.js";
+
+/**
+ * A generic function that we can use to search job posts based on a given criteria
+ *  It takes 6 parameters:
+ *
+ *  1: criteria: is a MongoDB object that we construct depending on what
+ *     filters or search terms we want.
+ *     e.g. const criteria = {
+ *               location: "Amsterdam",
+ *               tags: { $in: ["Full-time", "Remote"] },
+ *               title: /developer/i,
+ *            };
+ *
+ *  2: selectedFields: fields that we want to include in response.
+ *  3: populatedFields: fields that we want to include in from the referenced object, if any
+ *  sort, skip and limit are obvious ^_^
+ *  Note: we can even make this more generic by passing Model type and rename it 'findAnything'
+ */
+export const findJobs = async (
+  criteria = {},
+  selectedFields = " ",
+  populateFields = " ",
+  sort = { createdAt: -1 },
+  skip = 0,
+  limit = 10,
+) => {
+  let query = JobPost.find(criteria)
+    .select(selectedFields)
+    .sort(sort)
+    .skip(skip)
+    .limit(limit);
+
+  if (populateFields) {
+    query = query.populate({
+      path: "postedBy",
+      select: "companyProfile.companyName profilePhoto",
+    });
+  }
+
+  return await query.lean();
+};
 
 /**
  * Fetches recommended jobs using a tiered matching strategy.
@@ -23,21 +63,40 @@ export const recommendByCriteria = async (
   typeLabel,
   fallbackQuery,
 ) => {
+  if (!input) {
+    return {
+      success: false,
+      status: 400,
+      msg: "Invalid input for job recommendations.",
+    };
+  }
+
   const criteriaList = criteriaFn(input);
   let recommendedJobs = [];
-
   let matchLevel = "";
-  for (const criteria of criteriaList) {
-    matchLevel = criteria.type;
-    recommendedJobs = await JobPost.find(criteria.value).limit(10);
-    if (recommendedJobs.length) break;
-  }
 
-  if (!recommendedJobs.length) {
+  if (!criteriaList.length) {
     matchLevel = "recent";
     recommendedJobs = await fallbackQuery();
-  }
+  } else {
+    for (const criteria of criteriaList) {
+      matchLevel = criteria.type;
+      recommendedJobs = await findJobs(
+        criteria.value,
+        "title tags location description createdAt",
+        "postedBy",
+        { createdAt: -1 },
+        0,
+        10,
+      );
+      if (recommendedJobs.length) break;
+    }
 
+    if (!recommendedJobs.length) {
+      matchLevel = "recent";
+      recommendedJobs = await fallbackQuery();
+    }
+  }
   if (!recommendedJobs.length) {
     return { success: false, status: 404, msg: "No recommendations found." };
   }
@@ -48,21 +107,4 @@ export const recommendByCriteria = async (
     type: typeLabel,
     matchLevel: matchLevel,
   };
-};
-
-/** Populates job post with company info */
-export const populateJobsWithCompany = async (jobPosts) => {
-  return Promise.all(
-    jobPosts.map(async (jobPost) => {
-      const company = await User.findById(jobPost.postedBy)
-        .select("companyProfile.companyName profilePhoto")
-        .lean();
-
-      return {
-        ...jobPost.toObject(),
-        companyName: company?.companyProfile?.companyName || null,
-        profilePhoto: company?.profilePhoto,
-      };
-    }),
-  );
 };

--- a/server/src/middlewares/validateJobPost.js
+++ b/server/src/middlewares/validateJobPost.js
@@ -140,8 +140,8 @@ export const validateJobPost = [
   validate,
 ];
 
-/** Validates if user's userType is 'company' */
-export const validateIsCompany = async (req, res, next) => {
+/** Validates if user's userType is 'company' or 'seeker' */
+export const validateUserType = (userType) => async (req, res, next) => {
   const id = req.user?.id;
 
   const user = await User.findById(id);
@@ -151,11 +151,15 @@ export const validateIsCompany = async (req, res, next) => {
       .json({ success: false, msg: `No user with ${id} is found.` });
   }
 
-  if (user && user.userType !== "company") {
-    return res
-      .status(403)
-      .json({ success: false, msg: "Only company can post a job." });
+  if (user && user.userType !== userType) {
+    return res.status(403).json({
+      success: false,
+      msg: `Access denied. Only ${userType}s can access this resource.`,
+    });
   }
+
+  console.log("User: ", userType);
+  req.fullUser = user;
 
   next();
 };
@@ -163,6 +167,7 @@ export const validateIsCompany = async (req, res, next) => {
 /** Validates if a job exists */
 export const validateJobPostExists = async (req, res, next) => {
   const jobId = req.params.id;
+  console.log(jobId);
 
   if (!mongoose.Types.ObjectId.isValid(jobId)) {
     return res

--- a/server/src/middlewares/validateJobPost.js
+++ b/server/src/middlewares/validateJobPost.js
@@ -53,8 +53,8 @@ export const validateJobPost = [
     .withMessage("Title is required")
     .isString()
     .withMessage("Title must be a string")
-    .isLength({ min: 8, max: 200 })
-    .withMessage("Title must be between 8 and 200 characters"),
+    .isLength({ min: 3, max: 200 })
+    .withMessage("Title must be between 3 and 200 characters"),
 
   body("description")
     .trim()
@@ -157,8 +157,6 @@ export const validateUserType = (userType) => async (req, res, next) => {
       msg: `Access denied. Only ${userType}s can access this resource.`,
     });
   }
-
-  console.log("User: ", userType);
   req.fullUser = user;
 
   next();
@@ -167,7 +165,6 @@ export const validateUserType = (userType) => async (req, res, next) => {
 /** Validates if a job exists */
 export const validateJobPostExists = async (req, res, next) => {
   const jobId = req.params.id;
-  console.log(jobId);
 
   if (!mongoose.Types.ObjectId.isValid(jobId)) {
     return res

--- a/server/src/middlewares/validateJobPost.js
+++ b/server/src/middlewares/validateJobPost.js
@@ -83,6 +83,7 @@ export const validateJobPost = [
       arr.every((tag) => typeof tag === "string" && tag.trim().length <= 200),
     )
     .withMessage("Each requirement must be a string with max 200 characters."),
+
   body("numberOfOpenings")
     .exists()
     .withMessage("Number of openings is required")
@@ -113,6 +114,19 @@ export const validateJobPost = [
       arr.every((tag) => typeof tag === "string" && tag.trim().length <= 40),
     )
     .withMessage("Each tag must be a string with max 40 characters."),
+
+  body("languages")
+    .optional()
+    .isArray()
+    .withMessage("Languages must be an array.")
+    .bail()
+    .custom((arr) => arr.length <= MAX_NR_TAGS)
+    .withMessage(`Maximum ${MAX_NR_TAGS} langs allowed.`)
+    .bail()
+    .custom((arr) =>
+      arr.every((tag) => typeof tag === "string" && tag.trim().length <= 40),
+    )
+    .withMessage("Each lang must be a string with max 40 characters."),
 
   body("expireOn").optional().isISO8601().withMessage("Invalid date format"),
 

--- a/server/src/models/JobPost.js
+++ b/server/src/models/JobPost.js
@@ -86,6 +86,21 @@ const jobPostSchema = new Schema(
       },
     },
 
+    languages: {
+      type: [
+        {
+          type: String,
+          maxlength: 40,
+          trim: true,
+        },
+      ],
+      default: [],
+      validate: {
+        validator: (arr) => arr.length <= MAX_NR_TAGS,
+        message: "Max 10 lang allowed.",
+      },
+    },
+
     salaryMin: {
       type: Number,
       min: 0,

--- a/server/src/models/JobPost.js
+++ b/server/src/models/JobPost.js
@@ -20,7 +20,7 @@ const jobPostSchema = new Schema(
       type: String,
       trim: true,
       required: [true, "Job title is required."],
-      minlength: [8, "Title must be at least 8 characters"],
+      minlength: [3, "Title must be at least 8 characters"],
       maxlength: [200, "Title must be less than 200 characters"],
     },
 

--- a/server/src/models/User.js
+++ b/server/src/models/User.js
@@ -40,7 +40,7 @@ const UserSchema = new Schema(
   BaseOptions,
 );
 
-// validate allowed fields for the base user.
+// Validate allowed fields for the base user.
 UserSchema.statics.validateUser = function (userObj) {
   const errorList = [];
   const allowedKeys = ["email", "passwordHash", "location", "profilePhoto"];

--- a/server/src/routes/jobPosts.js
+++ b/server/src/routes/jobPosts.js
@@ -24,26 +24,28 @@ import asyncHandler from "../util/asyncHandler.js";
 
 const jobRouter = express.Router();
 
+// GET /api/jobs/recommendations -> gets recommendations based user profile
 jobRouter.get(
   "/recommendations",
   authMiddleware,
-  validateUserType("seeker"),
+  asyncHandler(validateUserType("seeker")),
   asyncHandler(recommendationsByProfile),
 );
 
+// GET /api/jobs/:id/similar-jobs-> gets recommendations based on recent viewed
 jobRouter.get(
   "/:id/similar-jobs",
   authMiddleware,
-  validateUserType("seeker"),
-  validateJobPostExists,
-  recommendationsByRecentView,
+  asyncHandler(validateUserType("seeker")),
+  asyncHandler(validateJobPostExists),
+  asyncHandler(recommendationsByRecentView),
 );
 
 // POST /api/jobs -> create a new job post
 jobRouter.post(
   "/",
   authMiddleware,
-  validateUserType("company"),
+  asyncHandler(validateUserType("company")),
   validateJobPost,
   asyncHandler(createJob),
 );
@@ -55,16 +57,16 @@ jobRouter.get("/:id", validateJobPostExists, asyncHandler(getJob));
 jobRouter.delete(
   "/:id",
   authMiddleware,
-  validateUserType("company"),
-  validateJobPostExists,
+  asyncHandler(validateUserType("company")),
+  asyncHandler(validateJobPostExists),
   asyncHandler(deleteJob),
 );
 
 jobRouter.patch(
   "/:id",
   authMiddleware,
-  validateUserType("company"),
-  validateJobPostExists,
+  asyncHandler(validateUserType("company")),
+  asyncHandler(validateJobPostExists),
   validateJobPost,
   asyncHandler(updateJob),
 );

--- a/server/src/routes/jobPosts.js
+++ b/server/src/routes/jobPosts.js
@@ -9,8 +9,13 @@ import {
 } from "../controllers/jobPost.js";
 
 import {
+  recommendationsByRecentView,
+  recommendationsByProfile,
+} from "../controllers/jobRecommendations.js";
+
+import {
   validateJobPost,
-  validateIsCompany,
+  validateUserType,
   validateJobPostExists,
 } from "../middlewares/validateJobPost.js";
 
@@ -19,11 +24,26 @@ import asyncHandler from "../util/asyncHandler.js";
 
 const jobRouter = express.Router();
 
+jobRouter.get(
+  "/recommendations",
+  authMiddleware,
+  validateUserType("seeker"),
+  asyncHandler(recommendationsByProfile),
+);
+
+jobRouter.get(
+  "/:id/similar-jobs",
+  authMiddleware,
+  validateUserType("seeker"),
+  validateJobPostExists,
+  recommendationsByRecentView,
+);
+
 // POST /api/jobs -> create a new job post
 jobRouter.post(
   "/",
   authMiddleware,
-  validateIsCompany,
+  validateUserType("company"),
   validateJobPost,
   asyncHandler(createJob),
 );
@@ -35,7 +55,7 @@ jobRouter.get("/:id", validateJobPostExists, asyncHandler(getJob));
 jobRouter.delete(
   "/:id",
   authMiddleware,
-  validateIsCompany,
+  validateUserType("company"),
   validateJobPostExists,
   asyncHandler(deleteJob),
 );
@@ -43,7 +63,7 @@ jobRouter.delete(
 jobRouter.patch(
   "/:id",
   authMiddleware,
-  validateIsCompany,
+  validateUserType("company"),
   validateJobPostExists,
   validateJobPost,
   asyncHandler(updateJob),

--- a/server/src/util/jobMatching/profileBased.js
+++ b/server/src/util/jobMatching/profileBased.js
@@ -5,31 +5,59 @@ import { escapeRegex } from "../utils.js";
  * moderate, and loose levels based on the user's(seeker) profile.
  */
 export const profileBasedMatchingCriterion = (user) => {
-  if (!user?.seekerProfile) return [];
-
   const {
     location,
-    seekerProfile: { preferences = [], skills = [], position = "" },
+    seekerProfile: {
+      preferences = [],
+      skills = [],
+      position = "",
+      languages = [],
+    } = {},
   } = user;
+
+  const isProfileIncomplete =
+    !location ||
+    !position ||
+    !skills.length ||
+    !preferences.length ||
+    !languages.length;
+
+  if (isProfileIncomplete) {
+    return [];
+  }
+
+  const titleCondition = { title: new RegExp(escapeRegex(position), "i") };
+  //const languageCondition = { languages: { $in: languages } };
 
   const strict = {
     $and: [
       { location: location },
       { tags: { $in: skills } },
       { type: { $in: preferences } },
-      { title: new RegExp(escapeRegex(position), "i") },
+      titleCondition,
+      //languageCondition,
     ],
   };
 
   const moderate = {
     $or: [
-      { $and: [{ location: location }, { tags: { $in: skills } }] },
-      { $and: [{ type: { $in: preferences } }, { tags: { $in: skills } }] },
       {
         $and: [
           { location: location },
-          { title: new RegExp(escapeRegex(position), "i") },
+          { tags: { $in: skills } },
+          //languageCondition,
         ],
+      },
+      {
+        $and: [
+          { type: { $in: preferences } },
+          { tags: { $in: skills } },
+          //languageCondition,
+        ],
+      },
+      {
+        // $and: [{ location: location }, titleCondition, languageCondition],
+        $and: [{ location: location }, titleCondition],
       },
     ],
   };
@@ -39,7 +67,8 @@ export const profileBasedMatchingCriterion = (user) => {
       { location: location },
       { tags: { $in: skills } },
       { type: { $in: preferences } },
-      { title: new RegExp(escapeRegex(position), "i") },
+      titleCondition,
+      //languageCondition,
     ],
   };
 

--- a/server/src/util/jobMatching/profileBased.js
+++ b/server/src/util/jobMatching/profileBased.js
@@ -1,13 +1,15 @@
-/**
- * Constructs an array of job matching criteria with strict, moderate, and loose levels
- * based on the user's profile.
- *
- */
+import { escapeRegex } from "../utils.js";
 
+/**
+ * Constructs an array of job matching criteria with strict,
+ * moderate, and loose levels based on the user's(seeker) profile.
+ */
 export const profileBasedMatchingCriterion = (user) => {
+  if (!user?.seekerProfile) return [];
+
   const {
     location,
-    seekerProfile: { preferences, skills, position },
+    seekerProfile: { preferences = [], skills = [], position = "" },
   } = user;
 
   const strict = {
@@ -15,20 +17,19 @@ export const profileBasedMatchingCriterion = (user) => {
       { location: location },
       { tags: { $in: skills } },
       { type: { $in: preferences } },
-      // { title: new RegExp(position, "i") },
+      { title: new RegExp(escapeRegex(position), "i") },
     ],
   };
 
   const moderate = {
     $or: [
+      { $and: [{ location: location }, { tags: { $in: skills } }] },
+      { $and: [{ type: { $in: preferences } }, { tags: { $in: skills } }] },
       {
-        $and: [{ location: location }, { tags: { $in: skills } }],
-      },
-      {
-        $and: [{ type: { $in: preferences } }, { tags: { $in: skills } }],
-      },
-      {
-        $and: [{ location: location }, { title: new RegExp(position, "i") }],
+        $and: [
+          { location: location },
+          { title: new RegExp(escapeRegex(position), "i") },
+        ],
       },
     ],
   };
@@ -38,7 +39,7 @@ export const profileBasedMatchingCriterion = (user) => {
       { location: location },
       { tags: { $in: skills } },
       { type: { $in: preferences } },
-      { title: new RegExp(position, "i") },
+      { title: new RegExp(escapeRegex(position), "i") },
     ],
   };
 

--- a/server/src/util/jobMatching/profileBased.js
+++ b/server/src/util/jobMatching/profileBased.js
@@ -1,0 +1,50 @@
+/**
+ * Constructs an array of job matching criteria with strict, moderate, and loose levels
+ * based on the user's profile.
+ *
+ */
+
+export const profileBasedMatchingCriterion = (user) => {
+  const {
+    location,
+    seekerProfile: { preferences, skills, position },
+  } = user;
+
+  const strict = {
+    $and: [
+      { location: location },
+      { tags: { $in: skills } },
+      { type: { $in: preferences } },
+      // { title: new RegExp(position, "i") },
+    ],
+  };
+
+  const moderate = {
+    $or: [
+      {
+        $and: [{ location: location }, { tags: { $in: skills } }],
+      },
+      {
+        $and: [{ type: { $in: preferences } }, { tags: { $in: skills } }],
+      },
+      {
+        $and: [{ location: location }, { title: new RegExp(position, "i") }],
+      },
+    ],
+  };
+
+  const loose = {
+    $or: [
+      { location: location },
+      { tags: { $in: skills } },
+      { type: { $in: preferences } },
+      { title: new RegExp(position, "i") },
+    ],
+  };
+
+  return [
+    { type: "strict", value: strict },
+    { type: "moderate", value: moderate },
+    { type: "loose", value: loose },
+  ];
+};

--- a/server/src/util/jobMatching/recentViewed.js
+++ b/server/src/util/jobMatching/recentViewed.js
@@ -1,70 +1,62 @@
 /**
  * Constructs an array of job matching criteria with strict, moderate, and loose levels
  * based on the recent clicked job post.
+ *
  * Ensures the clicked job itself is excluded from results.
+ *
+ * Note: This is basic implementation we can always improve(make it smart)by adding weight to the fields
+ *  like preference 3, skills 2... and calculate the score
  */
-export const recentViewMatchingCriterion = (clickedJob) => {
-  const { tags = [], location = "", type, title = "", _id } = clickedJob;
+
+import { escapeRegex } from "../utils.js";
+
+export const recentViewMatchingCriterion = (clickedJob = {}) => {
+  const { tags = [], location = "", type = "", title = "", _id } = clickedJob;
+  if (!_id) return [];
+
+  // To prevent unintended matches when the input contains special regex characters.
+  // for example C++, + is a regex quantifier so must me escaped
+  const regex = (val) => new RegExp(escapeRegex(val), "i");
+
+  const selfMatch = { _id: { $ne: _id } }; // do NOT include the clicked job
 
   const strict = {
     $and: [
+      selfMatch,
       { tags: { $in: tags } },
-      { location: new RegExp(location, "i") },
-      { type: type },
-      { title: new RegExp(title, "i") },
-      { _id: { $ne: _id } },
+      { location: regex(location) },
+      { type },
+      { title: regex(title) },
     ],
   };
 
   const moderate = {
-    $or: [
+    $and: [
+      selfMatch,
       {
-        $and: [
-          { tags: { $in: tags } },
-          { location: new RegExp(location, "i") },
-          { _id: { $ne: _id } },
-        ],
-      },
-      {
-        $and: [{ tags: { $in: tags } }, { type: type }, { _id: { $ne: _id } }],
-      },
-      {
-        $and: [
-          { location: new RegExp(location, "i") },
-          { type: type },
-          { _id: { $ne: _id } },
-        ],
-      },
-      {
-        $and: [
-          { title: new RegExp(title, "i") },
-          { tags: { $in: tags } },
-          { _id: { $ne: _id } },
-        ],
-      },
-      {
-        $and: [
-          { title: new RegExp(title, "i") },
-          { location: new RegExp(location, "i") },
-          { _id: { $ne: _id } },
-        ],
-      },
-      {
-        $and: [
-          { title: new RegExp(title, "i") },
-          { type: type },
-          { _id: { $ne: _id } },
+        $or: [
+          { $and: [{ tags: { $in: tags } }, { location: regex(location) }] },
+          { $and: [{ tags: { $in: tags } }, { type }] },
+          { $and: [{ location: regex(location) }, { type }] },
+          { $and: [{ title: regex(title) }, { tags: { $in: tags } }] },
+          { $and: [{ title: regex(title) }, { location: regex(location) }] },
+          { $and: [{ title: regex(title) }, { type }] },
         ],
       },
     ],
   };
 
   const loose = {
-    $or: [
-      { tags: { $in: tags }, _id: { $ne: _id } },
-      { location: new RegExp(location, "i"), _id: { $ne: _id } },
-      { type: type, _id: { $ne: _id } },
-      { title: new RegExp(title, "i"), _id: { $ne: _id } },
+    $and: [
+      selfMatch,
+      {
+        $or: [
+          { tags: { $in: tags } },
+          { location: regex(location) },
+          { type },
+          { title: regex(title) },
+        ],
+      },
     ],
   };
 

--- a/server/src/util/jobMatching/recentViewed.js
+++ b/server/src/util/jobMatching/recentViewed.js
@@ -1,0 +1,76 @@
+/**
+ * Constructs an array of job matching criteria with strict, moderate, and loose levels
+ * based on the recent clicked job post.
+ * Ensures the clicked job itself is excluded from results.
+ */
+export const recentViewMatchingCriterion = (clickedJob) => {
+  const { tags = [], location = "", type, title = "", _id } = clickedJob;
+
+  const strict = {
+    $and: [
+      { tags: { $in: tags } },
+      { location: new RegExp(location, "i") },
+      { type: type },
+      { title: new RegExp(title, "i") },
+      { _id: { $ne: _id } },
+    ],
+  };
+
+  const moderate = {
+    $or: [
+      {
+        $and: [
+          { tags: { $in: tags } },
+          { location: new RegExp(location, "i") },
+          { _id: { $ne: _id } },
+        ],
+      },
+      {
+        $and: [{ tags: { $in: tags } }, { type: type }, { _id: { $ne: _id } }],
+      },
+      {
+        $and: [
+          { location: new RegExp(location, "i") },
+          { type: type },
+          { _id: { $ne: _id } },
+        ],
+      },
+      {
+        $and: [
+          { title: new RegExp(title, "i") },
+          { tags: { $in: tags } },
+          { _id: { $ne: _id } },
+        ],
+      },
+      {
+        $and: [
+          { title: new RegExp(title, "i") },
+          { location: new RegExp(location, "i") },
+          { _id: { $ne: _id } },
+        ],
+      },
+      {
+        $and: [
+          { title: new RegExp(title, "i") },
+          { type: type },
+          { _id: { $ne: _id } },
+        ],
+      },
+    ],
+  };
+
+  const loose = {
+    $or: [
+      { tags: { $in: tags }, _id: { $ne: _id } },
+      { location: new RegExp(location, "i"), _id: { $ne: _id } },
+      { type: type, _id: { $ne: _id } },
+      { title: new RegExp(title, "i"), _id: { $ne: _id } },
+    ],
+  };
+
+  return [
+    { type: "strict", value: strict },
+    { type: "moderate", value: moderate },
+    { type: "loose", value: loose },
+  ];
+};

--- a/server/src/util/jobMatching/recentViewed.js
+++ b/server/src/util/jobMatching/recentViewed.js
@@ -9,24 +9,33 @@
  */
 
 import { escapeRegex } from "../utils.js";
-
 export const recentViewMatchingCriterion = (clickedJob = {}) => {
-  const { tags = [], location = "", type = "", title = "", _id } = clickedJob;
+  const {
+    tags = [],
+    location = "",
+    type = "",
+    title = "",
+    languages = [],
+    _id,
+  } = clickedJob;
+
   if (!_id) return [];
 
-  // To prevent unintended matches when the input contains special regex characters.
-  // for example C++, + is a regex quantifier so must me escaped
   const regex = (val) => new RegExp(escapeRegex(val), "i");
 
-  const selfMatch = { _id: { $ne: _id } }; // do NOT include the clicked job
+  const selfMatch = { _id: { $ne: _id } };
+  const titleCondition = { title: regex(title) };
+  const locationCondition = { location: regex(location) };
+  const languageCondition = { languages: { $in: languages } };
 
   const strict = {
     $and: [
       selfMatch,
       { tags: { $in: tags } },
-      { location: regex(location) },
+      locationCondition,
       { type },
-      { title: regex(title) },
+      titleCondition,
+      languageCondition,
     ],
   };
 
@@ -35,12 +44,28 @@ export const recentViewMatchingCriterion = (clickedJob = {}) => {
       selfMatch,
       {
         $or: [
-          { $and: [{ tags: { $in: tags } }, { location: regex(location) }] },
-          { $and: [{ tags: { $in: tags } }, { type }] },
-          { $and: [{ location: regex(location) }, { type }] },
-          { $and: [{ title: regex(title) }, { tags: { $in: tags } }] },
-          { $and: [{ title: regex(title) }, { location: regex(location) }] },
-          { $and: [{ title: regex(title) }, { type }] },
+          {
+            $and: [
+              { tags: { $in: tags } },
+              locationCondition,
+              languageCondition,
+            ],
+          },
+          {
+            $and: [{ tags: { $in: tags } }, { type }, languageCondition],
+          },
+          {
+            $and: [locationCondition, { type }, languageCondition],
+          },
+          {
+            $and: [titleCondition, { tags: { $in: tags } }, languageCondition],
+          },
+          {
+            $and: [titleCondition, locationCondition, languageCondition],
+          },
+          {
+            $and: [titleCondition, { type }, languageCondition],
+          },
         ],
       },
     ],
@@ -52,9 +77,10 @@ export const recentViewMatchingCriterion = (clickedJob = {}) => {
       {
         $or: [
           { tags: { $in: tags } },
-          { location: regex(location) },
+          locationCondition,
           { type },
-          { title: regex(title) },
+          titleCondition,
+          languageCondition,
         ],
       },
     ],

--- a/server/src/util/utils.js
+++ b/server/src/util/utils.js
@@ -8,3 +8,14 @@ export const removeDuplicates = (doc, fields) => {
 
 export const startOfToday = () => new Date(new Date().setHours(0, 0, 0, 0));
 export const endOfToday = () => new Date(new Date().setHours(23, 59, 59, 999));
+
+/**
+ *
+ * This is used to  escape special characters in user input
+ * before using it in a regular expression.
+ * This prevents regex injection and ensures that the input is treated
+ * as plain text, not as a regex pattern.
+ */
+export const escapeRegex = (text) => {
+  return text.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&");
+};


### PR DESCRIPTION
Added flexible job recommendation logic based on:
- user profile (skills, preferences, location)
- most recently clicked (viewed) job

Matching follows a progressive strategy:
strict -> moderate -> loose. 
If no matches are found, it falls back to returning the latest job posts.

Details:

- Matching criteria are built using MongoDB $and / $or logic
- Separated into reusable files for clarity:
  - utils/jobMatching/profileBased.js – profile-based recommendations
  - utils/jobMatching/recentViewed.js – clicked job-based recommendations

The shared utility function `recommendByCriteria` handles the recommendation logic.
It accepts:
- a criteria function (for profile or recent view logic)
- an input (user or jobPost)
- a label (used to tag the result type)
- a fallback query if no matches are found in any criteria level

Also ensures the clicked job is excluded from its own recommendation results.

New job endpoints added:

- GET /api/jobs/:id/similar-jobs
  Returns jobs similar to a clicked job, excluding the job itself.

- GET /api/jobs/recommendations
  Returns jobs that match the user’s profile.
