### PR TITLE
Profiles settings and updates

### DIFF
--- a/client/src/api/userService.js
+++ b/client/src/api/userService.js
@@ -39,4 +39,10 @@ export function register(userData) {
     body: userData,
   });
 }
-// additional functions can be added ..
+
+// this function is used to delete the user account.
+export function deleteAccount() {
+  return httpClient("/users/delete", {
+    method: "POST",
+  });
+}

--- a/client/src/components/UserPersonalProfile/Company/CompanyDetailsSection.jsx
+++ b/client/src/components/UserPersonalProfile/Company/CompanyDetailsSection.jsx
@@ -1,0 +1,121 @@
+import styles from "../Shared/settings.module.css";
+import PropTypes from "prop-types";
+const CompanyDetailsSection = ({ register, errors, isProcessing }) => (
+  <div className={styles.sectionContainer}>
+    <div className={styles.formField}>
+      <label htmlFor="companyName">Company Name:</label>
+      <input
+        className={`input-field${errors.companyName ? " input-error" : ""}`}
+        id="companyName"
+        type="text"
+        disabled={isProcessing}
+        {...register("companyName", {
+          required: "Company name cannot be empty",
+          maxLength: { value: 100, message: "Max 100 characters" },
+        })}
+      />
+      {errors.companyName && (
+        <p className={styles.errorText}>{errors.companyName.message}</p>
+      )}
+    </div>
+    <div className={styles.formField}>
+      <label htmlFor="industry">Industry:</label>
+      <input
+        className={`input-field${errors.industry ? " input-error" : ""}`}
+        id="industry"
+        type="text"
+        disabled={isProcessing}
+        {...register("industry", {
+          maxLength: { value: 60, message: "Max 60 characters" },
+        })}
+      />
+      {errors.industry && (
+        <p className={styles.errorText}>{errors.industry.message}</p>
+      )}
+    </div>
+    <div className={styles.formField}>
+      <label htmlFor="website">Website:</label>
+      <input
+        className={`input-field${errors.website ? " input-error" : ""}`}
+        id="website"
+        type="url"
+        disabled={isProcessing}
+        {...register("website")}
+      />
+      {errors.website && (
+        <p className={styles.errorText}>{errors.website.message}</p>
+      )}
+    </div>
+    <div className={styles.formField}>
+      <label htmlFor="companySize">Company Size:</label>
+      <input
+        className={`input-field${errors.companySize ? " input-error" : ""}`}
+        id="companySize"
+        type="text"
+        disabled={isProcessing}
+        {...register("companySize", {
+          maxLength: { value: 30, message: "Max 30 characters" },
+        })}
+        placeholder="e.g. 201-500"
+      />
+      {errors.companySize && (
+        <p className={styles.errorText}>{errors.companySize.message}</p>
+      )}
+    </div>
+    <div className={styles.formField}>
+      <label htmlFor="tagline">Tagline:</label>
+      <input
+        className={`input-field${errors.tagline ? " input-error" : ""}`}
+        id="tagline"
+        type="text"
+        disabled={isProcessing}
+        {...register("tagline", {
+          maxLength: { value: 100, message: "Max 100 characters" },
+        })}
+        placeholder="e.g. Innovate your future."
+      />
+      {errors.tagline && (
+        <p className={styles.errorText}>{errors.tagline.message}</p>
+      )}
+    </div>
+    <div className={styles.formField}>
+      <label htmlFor="headquarters">Headquarters:</label>
+      <input
+        className={`input-field${errors.headquarters ? " input-error" : ""}`}
+        id="headquarters"
+        type="text"
+        disabled={isProcessing}
+        {...register("headquarters", {
+          maxLength: { value: 60, message: "Max 60 characters" },
+        })}
+        placeholder="e.g. Amsterdam"
+      />
+      {errors.headquarters && (
+        <p className={styles.errorText}>{errors.headquarters.message}</p>
+      )}
+    </div>
+    <div className={styles.formField}>
+      <label htmlFor="about">About / Description:</label>
+      <textarea
+        className={`input-field${errors.about ? " input-error" : ""}`}
+        id="about"
+        disabled={isProcessing}
+        {...register("about", {
+          maxLength: { value: 500, message: "Max 500 characters" },
+        })}
+        placeholder="Describe your company..."
+      />
+      {errors.about && (
+        <p className={styles.errorText}>{errors.about.message}</p>
+      )}
+    </div>
+  </div>
+);
+
+CompanyDetailsSection.propTypes = {
+  register: PropTypes.func.isRequired,
+  errors: PropTypes.object.isRequired,
+  isProcessing: PropTypes.bool.isRequired,
+};
+
+export default CompanyDetailsSection;

--- a/client/src/components/UserPersonalProfile/Company/Settings.jsx
+++ b/client/src/components/UserPersonalProfile/Company/Settings.jsx
@@ -1,5 +1,233 @@
+import { useState, useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { useUser } from "../../../contexts/UserContext";
+import { uploadFileToCloudinary } from "../../../util/cloudinaryUpload";
+import styles from "../Shared/settings.module.css";
+import FeedbackMessage from "../Shared/SettingsSections/FeedbackMessage";
+import ProfilePhotoSection from "../Shared/SettingsSections/ProfilePhotoSection";
+import EmailLocationPassword from "../Shared/SettingsSections/EmailLocationPassword";
+import ArrayInputSection from "../Shared/SettingsSections/ArrayInputSection";
+import CompanyDetailsSection from "./CompanyDetailsSection";
+import { arrayFromString } from "../../../util/arrayFromString";
+
 const Settings = () => {
-  return <h1>Company Settings</h1>;
+  const { user, updateProfile, loading } = useUser();
+
+  const [feedback, setFeedback] = useState("");
+  const [uploadError, setUploadError] = useState("");
+  const [isProcessing, setIsProcessing] = useState(false);
+
+  // Clear feedback and error messages
+  useEffect(() => {
+    if (feedback || uploadError) {
+      const timer = setTimeout(() => {
+        setFeedback("");
+        setUploadError("");
+      }, 3000);
+      return () => clearTimeout(timer);
+    }
+  }, [feedback, uploadError]);
+
+  const {
+    register,
+    handleSubmit,
+    control,
+    reset,
+    watch,
+    formState: { errors, isSubmitting, dirtyFields },
+  } = useForm({
+    mode: "onChange",
+    defaultValues: {
+      email: user.email,
+      password: "",
+      location: user.location,
+      profilePhoto: null,
+      companyName: user.companyProfile.companyName,
+      website: user.companyProfile.website,
+      industry: user.companyProfile.industry,
+      about: user.companyProfile.about,
+      companySize: user.companyProfile.companySize,
+      tagline: user.companyProfile.tagline,
+      headquarters: user.companyProfile.headquarters,
+      branches: user.companyProfile.branches?.join(", ") || "",
+      values: user.companyProfile.values?.join(", ") || "",
+    },
+  });
+
+  //later will be ajdusted to handle loading state better
+  if (loading || !user || !user.companyProfile) {
+    return <div>Loading...</div>;
+  }
+  const onSubmit = async (data) => {
+    setIsProcessing(true);
+    setFeedback("");
+    setUploadError("");
+
+    try {
+      const updatePayload = {};
+      const companyProfileUpdates = {};
+
+      //  user fields
+      if (dirtyFields.email && data.email !== user.email)
+        updatePayload.email = data.email;
+      if (dirtyFields.password && data.password)
+        updatePayload.password = data.password;
+      if (dirtyFields.location && data.location !== user.location)
+        updatePayload.location = data.location;
+
+      // Profile photo
+      if (data.profilePhoto && data.profilePhoto.length > 0) {
+        const uploadedPhotoUrl = await uploadFileToCloudinary(
+          data.profilePhoto[0],
+        );
+        if (uploadedPhotoUrl && uploadedPhotoUrl !== user.profilePhoto) {
+          updatePayload.profilePhoto = uploadedPhotoUrl;
+        }
+      }
+
+      // Company profile fields
+      if (
+        dirtyFields.companyName &&
+        data.companyName !== user.companyProfile.companyName
+      )
+        companyProfileUpdates.companyName = data.companyName;
+      if (dirtyFields.website && data.website !== user.companyProfile.website)
+        companyProfileUpdates.website = data.website;
+      if (
+        dirtyFields.industry &&
+        data.industry !== user.companyProfile.industry
+      )
+        companyProfileUpdates.industry = data.industry;
+      if (dirtyFields.about && data.about !== user.companyProfile.about)
+        companyProfileUpdates.about = data.about;
+      if (
+        dirtyFields.companySize &&
+        data.companySize !== user.companyProfile.companySize
+      )
+        companyProfileUpdates.companySize = data.companySize;
+      if (dirtyFields.tagline && data.tagline !== user.companyProfile.tagline)
+        companyProfileUpdates.tagline = data.tagline;
+      if (
+        dirtyFields.headquarters &&
+        data.headquarters !== user.companyProfile.headquarters
+      )
+        companyProfileUpdates.headquarters = data.headquarters;
+
+      // Arrays
+      if (dirtyFields.branches) {
+        const branchesArr = arrayFromString(data.branches);
+        if (
+          JSON.stringify(branchesArr) !==
+          JSON.stringify(user.companyProfile.branches)
+        )
+          companyProfileUpdates.branches = branchesArr;
+      }
+      if (dirtyFields.values) {
+        const valuesArr = arrayFromString(data.values);
+        if (
+          JSON.stringify(valuesArr) !==
+          JSON.stringify(user.companyProfile.values)
+        )
+          companyProfileUpdates.values = valuesArr;
+      }
+
+      //  companyProfile
+      if (Object.keys(companyProfileUpdates).length > 0) {
+        updatePayload.companyProfile = companyProfileUpdates;
+      }
+
+      // If nothing changed, exit
+      if (Object.keys(updatePayload).length === 0) {
+        setFeedback("No changes to update.");
+        setIsProcessing(false);
+        return;
+      }
+
+      //  send update request
+      await updateProfile(updatePayload);
+
+      setFeedback("Profile updated successfully!");
+      reset(undefined, { keepValues: true });
+    } catch {
+      setUploadError("Failed to update profile. Please try again.");
+    } finally {
+      setIsProcessing(false);
+    }
+  };
+  return (
+    <div className={styles.settingsWrapper}>
+      <h1 className={styles.settingsTitle}>Edit Company Profile</h1>
+      <FeedbackMessage feedback={feedback} uploadError={uploadError} />
+
+      <form className={styles.settingsForm} onSubmit={handleSubmit(onSubmit)}>
+        <div style={{ marginBottom: "2rem" }}>
+          <ProfilePhotoSection
+            profilePhotoUrl={user.profilePhoto}
+            control={control}
+            errors={errors}
+            isProcessing={isProcessing}
+          />
+        </div>
+
+        <div className={styles.companyFormGrid}>
+          <CompanyDetailsSection
+            register={register}
+            errors={errors}
+            isProcessing={isProcessing}
+          />
+          <div>
+            <EmailLocationPassword
+              register={register}
+              errors={errors}
+              watch={watch}
+              isProcessing={isProcessing}
+              showLocation={true}
+              defaultLocation={user.location}
+            />
+            <ArrayInputSection
+              label="Branches (comma separated):"
+              name="branches"
+              isProcessing={isProcessing}
+              register={register}
+              errors={errors}
+              validate={(value) => {
+                const arr = arrayFromString(value);
+                if (arr.length > 10)
+                  return "You can add up to 10 branches only";
+                if (arr.some((s) => s.length > 50))
+                  return "Each branch must be less than 50 characters";
+                return true;
+              }}
+              placeholder="e.g. Amsterdam, Utrecht"
+            />
+            <ArrayInputSection
+              label="Company Values (comma separated):"
+              name="values"
+              register={register}
+              errors={errors}
+              isProcessing={isProcessing}
+              validate={(value) => {
+                const arr = arrayFromString(value);
+                if (arr.length > 10) return "You can add up to 10 values only";
+                if (arr.some((s) => s.length > 50))
+                  return "Each value must be less than 50 characters";
+                return true;
+              }}
+              placeholder="e.g. Innovation, Integrity, Teamwork"
+            />
+          </div>
+        </div>
+
+        <button
+          type="submit"
+          className="btn btn-primary"
+          disabled={isSubmitting || isProcessing}
+        >
+          {isSubmitting || isProcessing ? "Updating..." : "Update Profile"}
+        </button>
+      </form>
+    </div>
+  );
 };
 
 export default Settings;

--- a/client/src/components/UserPersonalProfile/Company/Settings.jsx
+++ b/client/src/components/UserPersonalProfile/Company/Settings.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
 import { useForm } from "react-hook-form";
 import { useUser } from "../../../contexts/UserContext";
 import { uploadFileToCloudinary } from "../../../util/cloudinaryUpload";
@@ -9,10 +10,11 @@ import EmailLocationPassword from "../Shared/SettingsSections/EmailLocationPassw
 import ArrayInputSection from "../Shared/SettingsSections/ArrayInputSection";
 import CompanyDetailsSection from "./CompanyDetailsSection";
 import { arrayFromString } from "../../../util/arrayFromString";
+import DeleteAccountButton from "../Shared/SettingsSections/DeleteAccountButton";
 
 const Settings = () => {
-  const { user, updateProfile, loading } = useUser();
-
+  const { user, updateProfile, loading, deleteAccount } = useUser();
+  const navigate = useNavigate();
   const [feedback, setFeedback] = useState("");
   const [uploadError, setUploadError] = useState("");
   const [isProcessing, setIsProcessing] = useState(false);
@@ -147,7 +149,8 @@ const Settings = () => {
       await updateProfile(updatePayload);
 
       setFeedback("Profile updated successfully!");
-      reset(undefined, { keepValues: true });
+      // Reset the form values to the updated user data
+      reset(data, { keepValues: true });
     } catch {
       setUploadError("Failed to update profile. Please try again.");
     } finally {
@@ -220,12 +223,30 @@ const Settings = () => {
 
         <button
           type="submit"
-          className="btn btn-primary"
+          className={styles.updateBtn}
           disabled={isSubmitting || isProcessing}
         >
           {isSubmitting || isProcessing ? "Updating..." : "Update Profile"}
         </button>
       </form>
+
+      <hr className={styles.settingsDivider} />
+      {/* Delete account button */}
+      <DeleteAccountButton
+        userEmail={user.email}
+        isProcessing={isProcessing}
+        onDelete={async () => {
+          setIsProcessing(true);
+          try {
+            await deleteAccount();
+            navigate("/");
+          } catch {
+            setUploadError("Failed to delete account.");
+          } finally {
+            setIsProcessing(false);
+          }
+        }}
+      />
     </div>
   );
 };

--- a/client/src/components/UserPersonalProfile/Seeker/EducationSection.jsx
+++ b/client/src/components/UserPersonalProfile/Seeker/EducationSection.jsx
@@ -1,0 +1,140 @@
+import { useState } from "react";
+import styles from "../Shared/settings.module.css";
+import PropTypes from "prop-types";
+
+const EducationSection = ({
+  eduFields,
+  register,
+  errors,
+  removeEdu,
+  appendEdu,
+}) => {
+  // open/closed state
+  const [openIndexes, setOpenIndexes] = useState([]);
+
+  const toggleOpen = (idx) => {
+    setOpenIndexes((prev) =>
+      prev.includes(idx) ? prev.filter((i) => i !== idx) : [...prev, idx],
+    );
+  };
+
+  return (
+    <div className={styles.sectionContainer}>
+      <h2>Education</h2>
+      {eduFields.map((item, idx) => {
+        const isOpen = openIndexes.includes(idx);
+        return (
+          <div key={item.id} className={styles.dynamicFieldGroup}>
+            <div
+              className={styles.collapsibleHeader}
+              onClick={() => toggleOpen(idx)}
+            >
+              <span>
+                {item.school || "School"} — {item.degree || "Degree"}
+              </span>
+              <span
+                className={`${styles.arrowIcon} ${isOpen ? styles.arrowOpen : ""}`}
+                aria-label={isOpen ? "Collapse" : "Expand"}
+              >
+                ▼
+              </span>
+            </div>
+            {isOpen && (
+              <>
+                <div className={styles.formField}>
+                  <label>School</label>
+                  <input
+                    className={`input-field${errors.education?.[idx]?.school ? " input-error" : ""}`}
+                    {...register(`education.${idx}.school`, {
+                      required: "School is required",
+                    })}
+                  />
+                  {errors.education?.[idx]?.school && (
+                    <p className={styles.errorText}>
+                      {errors.education[idx].school.message}
+                    </p>
+                  )}
+                </div>
+                <div className={styles.formField}>
+                  <label>Degree</label>
+                  <input
+                    className={`input-field${errors.education?.[idx]?.degree ? " input-error" : ""}`}
+                    {...register(`education.${idx}.degree`, {
+                      required: "Degree is required",
+                    })}
+                  />
+                  {errors.education?.[idx]?.degree && (
+                    <p className={styles.errorText}>
+                      {errors.education[idx].degree.message}
+                    </p>
+                  )}
+                </div>
+                <div className={styles.formField}>
+                  <label>Field of Study</label>
+                  <input
+                    className="input-field"
+                    {...register(`education.${idx}.fieldOfStudy`)}
+                  />
+                </div>
+                <div className={styles.formField}>
+                  <label>Location</label>
+                  <input
+                    className="input-field"
+                    {...register(`education.${idx}.educationLocation`)}
+                  />
+                </div>
+                <div className={styles.formField}>
+                  <label>Start Date</label>
+                  <input
+                    className={`input-field${errors.education?.[idx]?.startDate ? " input-error" : ""}`}
+                    type="date"
+                    {...register(`education.${idx}.startDate`, {
+                      required: "Start date required",
+                    })}
+                  />
+                  {errors.education?.[idx]?.startDate && (
+                    <p className={styles.errorText}>
+                      {errors.education[idx].startDate.message}
+                    </p>
+                  )}
+                </div>
+                <div className={styles.formField}>
+                  <label>End Date</label>
+                  <input
+                    className="input-field"
+                    type="date"
+                    {...register(`education.${idx}.endDate`)}
+                  />
+                </div>
+                <button
+                  type="button"
+                  className={styles.removeBtn}
+                  onClick={() => removeEdu(idx)}
+                >
+                  Remove
+                </button>
+              </>
+            )}
+          </div>
+        );
+      })}
+      <button
+        type="button"
+        className={styles.addBtn}
+        onClick={() => appendEdu({})}
+      >
+        Add Education
+      </button>
+    </div>
+  );
+};
+
+EducationSection.propTypes = {
+  eduFields: PropTypes.array.isRequired,
+  register: PropTypes.func.isRequired,
+  errors: PropTypes.object.isRequired,
+  removeEdu: PropTypes.func.isRequired,
+  appendEdu: PropTypes.func.isRequired,
+};
+
+export default EducationSection;

--- a/client/src/components/UserPersonalProfile/Seeker/EducationSection.jsx
+++ b/client/src/components/UserPersonalProfile/Seeker/EducationSection.jsx
@@ -45,8 +45,10 @@ const EducationSection = ({
                   <label>School</label>
                   <input
                     className={`input-field${errors.education?.[idx]?.school ? " input-error" : ""}`}
+                    maxLength={80}
                     {...register(`education.${idx}.school`, {
                       required: "School is required",
+                      maxLength: { value: 80, message: "Max 80 characters" },
                     })}
                   />
                   {errors.education?.[idx]?.school && (
@@ -59,8 +61,10 @@ const EducationSection = ({
                   <label>Degree</label>
                   <input
                     className={`input-field${errors.education?.[idx]?.degree ? " input-error" : ""}`}
+                    maxLength={80}
                     {...register(`education.${idx}.degree`, {
                       required: "Degree is required",
+                      maxLength: { value: 80, message: "Max 80 characters" },
                     })}
                   />
                   {errors.education?.[idx]?.degree && (
@@ -73,14 +77,20 @@ const EducationSection = ({
                   <label>Field of Study</label>
                   <input
                     className="input-field"
-                    {...register(`education.${idx}.fieldOfStudy`)}
+                    maxLength={80}
+                    {...register(`education.${idx}.fieldOfStudy`, {
+                      maxLength: { value: 80, message: "Max 80 characters" },
+                    })}
                   />
                 </div>
                 <div className={styles.formField}>
                   <label>Location</label>
                   <input
                     className="input-field"
-                    {...register(`education.${idx}.educationLocation`)}
+                    maxLength={80}
+                    {...register(`education.${idx}.educationLocation`, {
+                      maxLength: { value: 80, message: "Max 80 characters" },
+                    })}
                   />
                 </div>
                 <div className={styles.formField}>
@@ -103,8 +113,22 @@ const EducationSection = ({
                   <input
                     className="input-field"
                     type="date"
-                    {...register(`education.${idx}.endDate`)}
+                    {...register(`education.${idx}.endDate`, {
+                      validate: (endDate, formValues) => {
+                        const startDate =
+                          formValues.education?.[idx]?.startDate;
+                        if (endDate && startDate && endDate < startDate) {
+                          return "End date must be after start date";
+                        }
+                        return true;
+                      },
+                    })}
                   />
+                  {errors.education?.[idx]?.endDate && (
+                    <p className={styles.errorText}>
+                      {errors.education[idx].endDate.message}
+                    </p>
+                  )}
                 </div>
                 <button
                   type="button"

--- a/client/src/components/UserPersonalProfile/Seeker/EducationSection.jsx
+++ b/client/src/components/UserPersonalProfile/Seeker/EducationSection.jsx
@@ -118,10 +118,20 @@ const EducationSection = ({
           </div>
         );
       })}
+      {/* Button to add new education entry[empty] */}
       <button
         type="button"
         className={styles.addBtn}
-        onClick={() => appendEdu({})}
+        onClick={() =>
+          appendEdu({
+            school: "",
+            degree: "",
+            fieldOfStudy: "",
+            educationLocation: "",
+            startDate: "",
+            endDate: "",
+          })
+        }
       >
         Add Education
       </button>

--- a/client/src/components/UserPersonalProfile/Seeker/ExperienceSection.jsx
+++ b/client/src/components/UserPersonalProfile/Seeker/ExperienceSection.jsx
@@ -118,10 +118,20 @@ const ExperienceSection = ({
           </div>
         );
       })}
+      {/* Button to add a new experience entry with empty defualts */}
       <button
         type="button"
         className={styles.addBtn}
-        onClick={() => appendExp({})}
+        onClick={() =>
+          appendExp({
+            company: "",
+            title: "",
+            workLocation: "",
+            startDate: "",
+            endDate: "",
+            description: "",
+          })
+        }
       >
         Add Experience
       </button>

--- a/client/src/components/UserPersonalProfile/Seeker/ExperienceSection.jsx
+++ b/client/src/components/UserPersonalProfile/Seeker/ExperienceSection.jsx
@@ -45,8 +45,10 @@ const ExperienceSection = ({
                   <label>Company</label>
                   <input
                     className={`input-field${errors.experiences?.[idx]?.company ? " input-error" : ""}`}
+                    maxLength={80}
                     {...register(`experiences.${idx}.company`, {
                       required: "Company is required",
+                      maxLength: { value: 80, message: "Max 80 characters" },
                     })}
                   />
                   {errors.experiences?.[idx]?.company && (
@@ -59,8 +61,10 @@ const ExperienceSection = ({
                   <label>Title</label>
                   <input
                     className={`input-field${errors.experiences?.[idx]?.title ? " input-error" : ""}`}
+                    maxLength={80}
                     {...register(`experiences.${idx}.title`, {
                       required: "Title is required",
+                      maxLength: { value: 80, message: "Max 80 characters" },
                     })}
                   />
                   {errors.experiences?.[idx]?.title && (
@@ -73,7 +77,10 @@ const ExperienceSection = ({
                   <label>Location</label>
                   <input
                     className="input-field"
-                    {...register(`experiences.${idx}.workLocation`)}
+                    maxLength={80}
+                    {...register(`experiences.${idx}.workLocation`, {
+                      maxLength: { value: 80, message: "Max 80 characters" },
+                    })}
                   />
                 </div>
                 <div className={styles.formField}>
@@ -96,14 +103,31 @@ const ExperienceSection = ({
                   <input
                     className="input-field"
                     type="date"
-                    {...register(`experiences.${idx}.endDate`)}
+                    {...register(`experiences.${idx}.endDate`, {
+                      validate: (endDate, formValues) => {
+                        const startDate =
+                          formValues.experiences?.[idx]?.startDate;
+                        if (endDate && startDate && endDate < startDate) {
+                          return "End date must be after start date";
+                        }
+                        return true;
+                      },
+                    })}
                   />
+                  {errors.experiences?.[idx]?.endDate && (
+                    <p className={styles.errorText}>
+                      {errors.experiences[idx].endDate.message}
+                    </p>
+                  )}
                 </div>
                 <div className={styles.formField}>
                   <label>Description</label>
                   <textarea
                     className="input-field"
-                    {...register(`experiences.${idx}.description`)}
+                    maxLength={500}
+                    {...register(`experiences.${idx}.description`, {
+                      maxLength: { value: 500, message: "Max 500 characters" },
+                    })}
                   />
                 </div>
                 <button

--- a/client/src/components/UserPersonalProfile/Seeker/ExperienceSection.jsx
+++ b/client/src/components/UserPersonalProfile/Seeker/ExperienceSection.jsx
@@ -1,0 +1,138 @@
+import { useState } from "react";
+import styles from "../Shared/settings.module.css";
+import PropTypes from "prop-types";
+
+const ExperienceSection = ({
+  expFields,
+  register,
+  errors,
+  removeExp,
+  appendExp,
+}) => {
+  //  open/closed state for each entry
+  const [openIndexes, setOpenIndexes] = useState([]);
+
+  const toggleOpen = (idx) => {
+    setOpenIndexes((prev) =>
+      prev.includes(idx) ? prev.filter((i) => i !== idx) : [...prev, idx],
+    );
+  };
+
+  return (
+    <div className={styles.sectionContainer}>
+      <h2>Experience</h2>
+      {expFields.map((item, idx) => {
+        const isOpen = openIndexes.includes(idx);
+        return (
+          <div key={item.id} className={styles.dynamicFieldGroup}>
+            <div
+              className={styles.collapsibleHeader}
+              onClick={() => toggleOpen(idx)}
+            >
+              <span>
+                {item.company || "Company"} — {item.title || "Title"}
+              </span>
+              <span
+                className={`${styles.arrowIcon} ${isOpen ? styles.arrowOpen : ""}`}
+                aria-label={isOpen ? "Collapse" : "Expand"}
+              >
+                ▼
+              </span>
+            </div>
+            {isOpen && (
+              <>
+                <div className={styles.formField}>
+                  <label>Company</label>
+                  <input
+                    className={`input-field${errors.experiences?.[idx]?.company ? " input-error" : ""}`}
+                    {...register(`experiences.${idx}.company`, {
+                      required: "Company is required",
+                    })}
+                  />
+                  {errors.experiences?.[idx]?.company && (
+                    <p className={styles.errorText}>
+                      {errors.experiences[idx].company.message}
+                    </p>
+                  )}
+                </div>
+                <div className={styles.formField}>
+                  <label>Title</label>
+                  <input
+                    className={`input-field${errors.experiences?.[idx]?.title ? " input-error" : ""}`}
+                    {...register(`experiences.${idx}.title`, {
+                      required: "Title is required",
+                    })}
+                  />
+                  {errors.experiences?.[idx]?.title && (
+                    <p className={styles.errorText}>
+                      {errors.experiences[idx].title.message}
+                    </p>
+                  )}
+                </div>
+                <div className={styles.formField}>
+                  <label>Location</label>
+                  <input
+                    className="input-field"
+                    {...register(`experiences.${idx}.workLocation`)}
+                  />
+                </div>
+                <div className={styles.formField}>
+                  <label>Start Date</label>
+                  <input
+                    className={`input-field${errors.experiences?.[idx]?.startDate ? " input-error" : ""}`}
+                    type="date"
+                    {...register(`experiences.${idx}.startDate`, {
+                      required: "Start date required",
+                    })}
+                  />
+                  {errors.experiences?.[idx]?.startDate && (
+                    <p className={styles.errorText}>
+                      {errors.experiences[idx].startDate.message}
+                    </p>
+                  )}
+                </div>
+                <div className={styles.formField}>
+                  <label>End Date</label>
+                  <input
+                    className="input-field"
+                    type="date"
+                    {...register(`experiences.${idx}.endDate`)}
+                  />
+                </div>
+                <div className={styles.formField}>
+                  <label>Description</label>
+                  <textarea
+                    className="input-field"
+                    {...register(`experiences.${idx}.description`)}
+                  />
+                </div>
+                <button
+                  type="button"
+                  className={styles.removeBtn}
+                  onClick={() => removeExp(idx)}
+                >
+                  Remove
+                </button>
+              </>
+            )}
+          </div>
+        );
+      })}
+      <button
+        type="button"
+        className={styles.addBtn}
+        onClick={() => appendExp({})}
+      >
+        Add Experience
+      </button>
+    </div>
+  );
+};
+ExperienceSection.propTypes = {
+  expFields: PropTypes.array.isRequired,
+  register: PropTypes.func.isRequired,
+  errors: PropTypes.object.isRequired,
+  removeExp: PropTypes.func.isRequired,
+  appendExp: PropTypes.func.isRequired,
+};
+export default ExperienceSection;

--- a/client/src/components/UserPersonalProfile/Seeker/PersonalDetailsSection.jsx
+++ b/client/src/components/UserPersonalProfile/Seeker/PersonalDetailsSection.jsx
@@ -1,0 +1,79 @@
+import styles from "../Shared/settings.module.css";
+import PropTypes from "prop-types";
+
+const PersonalDetailsSection = ({ register, errors, isProcessing }) => (
+  <div className={styles.sectionContainer}>
+    <div className={styles.formField}>
+      <label htmlFor="firstName">First Name:</label>
+      <input
+        className={`input-field${errors.firstName ? " input-error" : ""}`}
+        id="firstName"
+        type="text"
+        disabled={isProcessing}
+        {...register("firstName", {
+          required: "First name cannot be empty",
+        })}
+      />
+      {errors.firstName && (
+        <p className={styles.errorText}>{errors.firstName.message}</p>
+      )}
+    </div>
+    <div className={styles.formField}>
+      <label htmlFor="lastName">Last Name:</label>
+      <input
+        className={`input-field${errors.lastName ? " input-error" : ""}`}
+        id="lastName"
+        type="text"
+        disabled={isProcessing}
+        {...register("lastName", {
+          required: "Last name cannot be empty",
+        })}
+      />
+      {errors.lastName && (
+        <p className={styles.errorText}>{errors.lastName.message}</p>
+      )}
+    </div>
+    <div className={styles.formField}>
+      <label htmlFor="position">Position:</label>
+      <input
+        className={`input-field${errors.position ? " input-error" : ""}`}
+        id="position"
+        type="text"
+        disabled={isProcessing}
+        placeholder="e.g. Frontend Developer"
+        {...register("position", {
+          maxLength: {
+            value: 99,
+            message: "Position must be less than 99 characters",
+          },
+        })}
+      />
+      {errors.position && (
+        <p className={styles.errorText}>{errors.position.message}</p>
+      )}
+    </div>
+    <div className={styles.formField}>
+      <label htmlFor="bio">Bio:</label>
+      <textarea
+        className={`input-field${errors.bio ? " input-error" : ""}`}
+        id="bio"
+        disabled={isProcessing}
+        placeholder="Tell us about yourself..."
+        {...register("bio", {
+          maxLength: {
+            value: 499,
+            message: "Bio must be less than 499 characters",
+          },
+        })}
+      />
+      {errors.bio && <p className={styles.errorText}>{errors.bio.message}</p>}
+    </div>
+  </div>
+);
+
+PersonalDetailsSection.propTypes = {
+  register: PropTypes.func.isRequired,
+  errors: PropTypes.object.isRequired,
+  isProcessing: PropTypes.bool.isRequired,
+};
+export default PersonalDetailsSection;

--- a/client/src/components/UserPersonalProfile/Seeker/ResumeSection.jsx
+++ b/client/src/components/UserPersonalProfile/Seeker/ResumeSection.jsx
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import { useState } from "react";
 import { useUser } from "../../../contexts/UserContext";
 import { Controller } from "react-hook-form";
-import { MdDelete } from "react-icons/md";
+import { MdDelete, MdUpload } from "react-icons/md";
 import styles from "../Shared/settings.module.css";
 
 const ResumeSection = ({ resumeUrl, control, errors, isProcessing }) => {
@@ -51,7 +51,9 @@ const ResumeSection = ({ resumeUrl, control, errors, isProcessing }) => {
         </div>
       </div>
       <div>
-        <label htmlFor="resume">Upload New CV (PDF)</label>
+        <label htmlFor="resume" className={styles.uploadBtn} title="Upload CV">
+          <MdUpload size={22} style={{ verticalAlign: "middle" }} />
+        </label>
         <Controller
           control={control}
           name="resume"
@@ -63,6 +65,7 @@ const ResumeSection = ({ resumeUrl, control, errors, isProcessing }) => {
               onChange={(e) => onChange(e.target.files)}
               ref={ref}
               disabled={isProcessing}
+              style={{ display: "none" }}
             />
           )}
         />

--- a/client/src/components/UserPersonalProfile/Seeker/ResumeSection.jsx
+++ b/client/src/components/UserPersonalProfile/Seeker/ResumeSection.jsx
@@ -1,0 +1,83 @@
+import PropTypes from "prop-types";
+
+import { useState } from "react";
+import { useUser } from "../../../contexts/UserContext";
+import { Controller } from "react-hook-form";
+import { MdDelete } from "react-icons/md";
+import styles from "../Shared/settings.module.css";
+
+const ResumeSection = ({ resumeUrl, control, errors, isProcessing }) => {
+  const { updateProfile } = useUser();
+  const [deleteError, setDeleteError] = useState("");
+
+  const handleDelete = async () => {
+    setDeleteError("");
+    try {
+      await updateProfile({ seekerProfile: { resumeUrl: "" } });
+    } catch {
+      setDeleteError("Failed to delete CV");
+    }
+  };
+
+  return (
+    <div className={styles.resumeSection}>
+      <div className={styles.settingsCvLink}>
+        <label>CV (PDF)</label>
+        <div className={styles.cvActionsRow}>
+          {resumeUrl ? (
+            <>
+              <a
+                href={resumeUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className={styles.viewCvBtn}
+              >
+                View current CV
+              </a>
+              <button
+                type="button"
+                className={styles.deleteCvBtn}
+                onClick={handleDelete}
+                title="Delete CV"
+              >
+                <MdDelete />
+              </button>
+            </>
+          ) : (
+            <span style={{ color: "var(--text-secondary-color, #888)" }}>
+              No CV uploaded
+            </span>
+          )}
+        </div>
+      </div>
+      <div>
+        <label htmlFor="resume">Upload New CV (PDF)</label>
+        <Controller
+          control={control}
+          name="resume"
+          render={({ field: { onChange, ref } }) => (
+            <input
+              id="resume"
+              type="file"
+              accept="application/pdf"
+              onChange={(e) => onChange(e.target.files)}
+              ref={ref}
+              disabled={isProcessing}
+            />
+          )}
+        />
+        {errors.resume && (
+          <p className={styles.errorText}>{errors.resume.message}</p>
+        )}
+        {deleteError && <p className={styles.errorText}>{deleteError}</p>}
+      </div>
+    </div>
+  );
+};
+ResumeSection.propTypes = {
+  resumeUrl: PropTypes.string,
+  control: PropTypes.object.isRequired,
+  errors: PropTypes.object.isRequired,
+  isProcessing: PropTypes.bool.isRequired,
+};
+export default ResumeSection;

--- a/client/src/components/UserPersonalProfile/Seeker/Settings.jsx
+++ b/client/src/components/UserPersonalProfile/Seeker/Settings.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
 import { useForm, useFieldArray } from "react-hook-form";
 import { useUser } from "../../../contexts/UserContext";
 import { uploadFileToCloudinary } from "../../../util/cloudinaryUpload";
@@ -13,10 +14,11 @@ import ProfilePhotoSection from "../Shared/SettingsSections/ProfilePhotoSection"
 import EmailLocationPassword from "../Shared/SettingsSections/EmailLocationPassword";
 import ResumeSection from "./ResumeSection";
 import PersonalDetailsSection from "./PersonalDetailsSection";
+import DeleteAccountButton from "../Shared/SettingsSections/DeleteAccountButton";
 
 const SeekerSettings = () => {
-  const { user, updateProfile, loading } = useUser();
-
+  const { user, updateProfile, loading, deleteAccount } = useUser();
+  const navigate = useNavigate();
   const [feedback, setFeedback] = useState("");
   const [uploadError, setUploadError] = useState("");
   const [isProcessing, setIsProcessing] = useState(false);
@@ -94,6 +96,9 @@ const SeekerSettings = () => {
         updatePayload.email = data.email;
       if (dirtyFields.password && data.password.trim().length >= 8)
         updatePayload.password = data.password;
+      // location field
+      if (dirtyFields.location && data.location !== user.location)
+        updatePayload.location = data.location;
 
       //  profile fields
       const seekerProfileUpdates = {};
@@ -194,8 +199,8 @@ const SeekerSettings = () => {
 
       await updateProfile(updatePayload);
       setFeedback("Profile updated successfully!");
-
-      reset(undefined, { keepValues: true }); // reset dirtyFields
+      // Reset the form values to the updated user data
+      reset(data, { keepValues: true });
     } catch (error) {
       setUploadError(
         error.message || "Something went wrong while updating the profile.",
@@ -274,6 +279,7 @@ const SeekerSettings = () => {
             }}
             placeholder="e.g. English, Spanish"
           />
+
           <ArrayInputSection
             label="Preferences (comma separated):"
             name="preferences"
@@ -320,8 +326,22 @@ const SeekerSettings = () => {
       </form>
 
       <hr className={styles.settingsDivider} />
-
-      {/* Delete will come later*/}
+      {/* Delete account button */}
+      <DeleteAccountButton
+        userEmail={user.email}
+        isProcessing={isProcessing}
+        onDelete={async () => {
+          setIsProcessing(true);
+          try {
+            await deleteAccount();
+            navigate("/");
+          } catch {
+            setUploadError("Failed to delete account.");
+          } finally {
+            setIsProcessing(false);
+          }
+        }}
+      />
     </div>
   );
 };

--- a/client/src/components/UserPersonalProfile/Seeker/Settings.jsx
+++ b/client/src/components/UserPersonalProfile/Seeker/Settings.jsx
@@ -1,5 +1,329 @@
-const Settings = () => {
-  return <h1>Seeker Settings</h1>;
+import { useState, useEffect } from "react";
+import { useForm, useFieldArray } from "react-hook-form";
+import { useUser } from "../../../contexts/UserContext";
+import { uploadFileToCloudinary } from "../../../util/cloudinaryUpload";
+import { arrayFromString } from "../../../util/arrayFromString";
+
+import styles from "../Shared/settings.module.css";
+import ExperienceSection from "./ExperienceSection";
+import EducationSection from "./EducationSection";
+import ArrayInputSection from "../Shared/SettingsSections/ArrayInputSection";
+import FeedbackMessage from "../Shared/SettingsSections/FeedbackMessage";
+import ProfilePhotoSection from "../Shared/SettingsSections/ProfilePhotoSection";
+import EmailLocationPassword from "../Shared/SettingsSections/EmailLocationPassword";
+import ResumeSection from "./ResumeSection";
+import PersonalDetailsSection from "./PersonalDetailsSection";
+
+const SeekerSettings = () => {
+  const { user, updateProfile, loading } = useUser();
+
+  const [feedback, setFeedback] = useState("");
+  const [uploadError, setUploadError] = useState("");
+  const [isProcessing, setIsProcessing] = useState(false);
+
+  // clear feedback and error messages
+  useEffect(() => {
+    if (feedback || uploadError) {
+      const timer = setTimeout(() => {
+        setFeedback("");
+        setUploadError("");
+      }, 3000);
+      return () => clearTimeout(timer);
+    }
+  }, [feedback, uploadError]);
+
+  const {
+    register,
+    handleSubmit,
+    control,
+    setError,
+    reset,
+    watch,
+    formState: { errors, isSubmitting, dirtyFields },
+  } = useForm({
+    mode: "onChange",
+    defaultValues: {
+      email: user.email,
+      password: "",
+      location: user.location,
+      firstName: user.seekerProfile.firstName,
+      lastName: user.seekerProfile.lastName,
+      position: user.seekerProfile.position,
+      bio: user.seekerProfile.bio,
+      skills: user.seekerProfile.skills?.join(", ") || "",
+      languages: user.seekerProfile.languages?.join(", ") || "",
+      preferences: user.seekerProfile.preferences?.join(", ") || "",
+      experiences: user.seekerProfile.experiences || [],
+      education: user.seekerProfile.education || [],
+      profilePhoto: null,
+      resume: null,
+    },
+  });
+
+  const {
+    fields: expFields,
+    append: appendExp,
+    remove: removeExp,
+  } = useFieldArray({
+    control,
+    name: "experiences",
+  });
+  const {
+    fields: eduFields,
+    append: appendEdu,
+    remove: removeEdu,
+  } = useFieldArray({
+    control,
+    name: "education",
+  });
+
+  // later will add a spinner
+  if (loading || !user || !user.seekerProfile) {
+    return <div>Loading...</div>;
+  }
+  const onSubmit = async (data) => {
+    if (isProcessing) return;
+    setIsProcessing(true);
+    setFeedback("");
+    setUploadError("");
+    try {
+      const updatePayload = {};
+
+      // base fields
+      if (dirtyFields.email && data.email !== user.email)
+        updatePayload.email = data.email;
+      if (dirtyFields.password && data.password.trim().length >= 8)
+        updatePayload.password = data.password;
+
+      //  profile fields
+      const seekerProfileUpdates = {};
+      if (
+        dirtyFields.firstName &&
+        data.firstName !== user.seekerProfile.firstName
+      )
+        seekerProfileUpdates.firstName = data.firstName;
+      if (dirtyFields.lastName && data.lastName !== user.seekerProfile.lastName)
+        seekerProfileUpdates.lastName = data.lastName;
+      if (dirtyFields.position && data.position !== user.seekerProfile.position)
+        seekerProfileUpdates.position = data.position;
+      if (dirtyFields.bio && data.bio !== user.seekerProfile.bio)
+        seekerProfileUpdates.bio = data.bio;
+
+      // Arrays
+      if (dirtyFields.skills) {
+        const skillsArr = arrayFromString(data.skills);
+        if (
+          JSON.stringify(skillsArr) !==
+          JSON.stringify(user.seekerProfile.skills)
+        )
+          seekerProfileUpdates.skills = skillsArr;
+      }
+      if (dirtyFields.languages) {
+        const languagesArr = arrayFromString(data.languages);
+        if (
+          JSON.stringify(languagesArr) !==
+          JSON.stringify(user.seekerProfile.languages)
+        )
+          seekerProfileUpdates.languages = languagesArr;
+      }
+      if (dirtyFields.preferences) {
+        const preferencesArr = arrayFromString(data.preferences);
+        if (
+          JSON.stringify(preferencesArr) !==
+          JSON.stringify(user.seekerProfile.preferences)
+        )
+          seekerProfileUpdates.preferences = preferencesArr;
+      }
+      if (dirtyFields.experiences) {
+        if (
+          JSON.stringify(data.experiences) !==
+          JSON.stringify(user.seekerProfile.experiences)
+        ) {
+          seekerProfileUpdates.experiences = data.experiences;
+        }
+      }
+      if (dirtyFields.education) {
+        if (
+          JSON.stringify(data.education) !==
+          JSON.stringify(user.seekerProfile.education)
+        ) {
+          seekerProfileUpdates.education = data.education;
+        }
+      }
+
+      // Profile Photo
+      if (data.profilePhoto && data.profilePhoto.length > 0) {
+        const uploadedPhotoUrl = await uploadFileToCloudinary(
+          data.profilePhoto[0],
+        );
+
+        if (uploadedPhotoUrl && uploadedPhotoUrl !== user.profilePhoto) {
+          updatePayload.profilePhoto = uploadedPhotoUrl;
+        }
+      }
+
+      // Resume / CV (PDF only)
+      if (data.resume && data.resume.length > 0) {
+        const cvFile = data.resume[0];
+        if (cvFile.type !== "application/pdf") {
+          setError("resume", {
+            type: "manual",
+            message: "CV must be a PDF file.",
+          });
+          setIsProcessing(false);
+          return;
+        }
+        const uploadedResumeUrl = await uploadFileToCloudinary(cvFile);
+        if (
+          uploadedResumeUrl &&
+          uploadedResumeUrl !== user.seekerProfile.resumeUrl
+        ) {
+          seekerProfileUpdates.resumeUrl = uploadedResumeUrl;
+        }
+      }
+
+      if (Object.keys(seekerProfileUpdates).length > 0) {
+        updatePayload.seekerProfile = seekerProfileUpdates;
+      }
+
+      if (Object.keys(updatePayload).length === 0) {
+        setFeedback("No changes detected.");
+        setIsProcessing(false);
+        return;
+      }
+
+      await updateProfile(updatePayload);
+      setFeedback("Profile updated successfully!");
+
+      reset(undefined, { keepValues: true }); // reset dirtyFields
+    } catch (error) {
+      setUploadError(
+        error.message || "Something went wrong while updating the profile.",
+      );
+    } finally {
+      setIsProcessing(false);
+    }
+  };
+
+  return (
+    <div className={styles.settingsWrapper}>
+      <h1 className={styles.settingsTitle}>Edit Your Profile</h1>
+
+      {/* Feedback error messages */}
+      <FeedbackMessage feedback={feedback} uploadError={uploadError} />
+
+      <form className={styles.settingsForm} onSubmit={handleSubmit(onSubmit)}>
+        <div className={styles.formGrid}>
+          {/* Photo & CV section */}
+          <ProfilePhotoSection
+            profilePhotoUrl={user.profilePhoto}
+            control={control}
+            errors={errors}
+            isProcessing={isProcessing}
+          />
+          <ResumeSection
+            resumeUrl={user.seekerProfile.resumeUrl}
+            control={control}
+            errors={errors}
+            isProcessing={isProcessing}
+          />
+          {/* Email, Password section */}
+          <EmailLocationPassword
+            register={register}
+            errors={errors}
+            watch={watch}
+            isProcessing={isProcessing}
+            showLocation={true}
+            defaultLocation={user.location}
+          />
+
+          {/*Personal details section */}
+
+          <PersonalDetailsSection
+            register={register}
+            errors={errors}
+            isProcessing={isProcessing}
+          />
+
+          {/* Skills, Languages, Preferences  */}
+          <ArrayInputSection
+            label="Skills (comma separated):"
+            name="skills"
+            register={register}
+            errors={errors}
+            validate={(value) => {
+              const arr = arrayFromString(value);
+              if (arr.length > 20) return "You can add up to 20 skills only";
+              if (arr.some((s) => s.length > 50))
+                return "Each skill must be less than 50 characters";
+              return true;
+            }}
+            placeholder="e.g. JavaScript, React, Node.js"
+          />
+          <ArrayInputSection
+            label="Languages (comma separated):"
+            name="languages"
+            register={register}
+            errors={errors}
+            validate={(value) => {
+              const arr = arrayFromString(value);
+              if (arr.length > 20) return "You can add up to 20 languages only";
+              if (arr.some((s) => s.length > 50))
+                return "Each language must be less than 50 characters";
+              return true;
+            }}
+            placeholder="e.g. English, Spanish"
+          />
+          <ArrayInputSection
+            label="Preferences (comma separated):"
+            name="preferences"
+            register={register}
+            errors={errors}
+            validate={(value) => {
+              const arr = arrayFromString(value);
+              if (arr.length > 20)
+                return "You can add up to 20 preferences only";
+              if (arr.some((s) => s.length > 50))
+                return "Each preference must be less than 50 characters";
+              return true;
+            }}
+            placeholder="e.g. Remote, Full-time"
+          />
+        </div>
+
+        {/* Experiences section and educations */}
+
+        <div className={styles.expEduGrid}>
+          <ExperienceSection
+            expFields={expFields}
+            register={register}
+            errors={errors}
+            removeExp={removeExp}
+            appendExp={appendExp}
+          />
+          <EducationSection
+            eduFields={eduFields}
+            register={register}
+            errors={errors}
+            removeEdu={removeEdu}
+            appendEdu={appendEdu}
+          />
+        </div>
+
+        <button
+          type="submit"
+          className={styles.updateBtn}
+          disabled={isSubmitting || isProcessing}
+        >
+          {isSubmitting || isProcessing ? "Updating..." : "Update Profile"}
+        </button>
+      </form>
+
+      <hr className={styles.settingsDivider} />
+
+      {/* Delete will come later*/}
+    </div>
+  );
 };
 
-export default Settings;
+export default SeekerSettings;

--- a/client/src/components/UserPersonalProfile/Shared/OverviewHeader.jsx
+++ b/client/src/components/UserPersonalProfile/Shared/OverviewHeader.jsx
@@ -1,4 +1,4 @@
-import { MdEmail, MdLocationOn } from "react-icons/md";
+import { MdEmail, MdLocationOn, MdPublic } from "react-icons/md";
 import { useUser } from "../../../contexts/UserContext";
 import { useNavigate } from "react-router-dom";
 import styles from "./header-section.module.css";
@@ -9,7 +9,7 @@ const OverviewHeader = () => {
   const navigate = useNavigate();
   if (!user) return null;
 
-  const { userType, email, profilePhoto, location } = user;
+  const { userType, email, profilePhoto, location, _id } = user;
 
   // Seeker fields
   const seekerProfile = user.seekerProfile || {};
@@ -32,6 +32,16 @@ const OverviewHeader = () => {
       navigate("/profile/company-settings");
     } else {
       navigate("/profile/seeker-settings");
+    }
+  };
+
+  // View as public
+
+  const handleViewPublicClick = () => {
+    if (userType === "company") {
+      navigate(`/users/company-profile/${_id}`);
+    } else {
+      navigate(`/users/candidate-profile/${_id}`);
     }
   };
 
@@ -68,10 +78,15 @@ const OverviewHeader = () => {
       </div>
       <div className={styles.rightSection}>
         <button
-          id="contactBtnId"
+          type="button"
           className="btn btn-primary"
-          onClick={handleEditClick}
+          style={{ marginRight: "0.5rem" }}
+          onClick={handleViewPublicClick}
+          title="View as Public"
         >
+          <MdPublic size={20} style={{ verticalAlign: "middle" }} />
+        </button>
+        <button className="btn btn-primary" onClick={handleEditClick}>
           Edit
         </button>
       </div>

--- a/client/src/components/UserPersonalProfile/Shared/SettingsSections/ArrayInputSection.jsx
+++ b/client/src/components/UserPersonalProfile/Shared/SettingsSections/ArrayInputSection.jsx
@@ -10,7 +10,7 @@ const ArrayInputSection = ({
   isProcessing,
   placeholder = "",
 }) => (
-  <div className={styles.arrayInputSection}>
+  <div>
     <label htmlFor={name}>{label}</label>
     <input
       className={`input-field${errors[name] ? " input-error" : ""}`}

--- a/client/src/components/UserPersonalProfile/Shared/SettingsSections/ArrayInputSection.jsx
+++ b/client/src/components/UserPersonalProfile/Shared/SettingsSections/ArrayInputSection.jsx
@@ -1,0 +1,37 @@
+import styles from "../settings.module.css";
+import PropTypes from "prop-types";
+
+const ArrayInputSection = ({
+  label,
+  name,
+  register,
+  errors,
+  validate,
+  isProcessing,
+  placeholder = "",
+}) => (
+  <div className={styles.arrayInputSection}>
+    <label htmlFor={name}>{label}</label>
+    <input
+      className={`input-field${errors[name] ? " input-error" : ""}`}
+      id={name}
+      type="text"
+      disabled={isProcessing}
+      placeholder={placeholder}
+      {...register(name, { validate })}
+    />
+    {errors[name] && <p className={styles.errorText}>{errors[name].message}</p>}
+  </div>
+);
+
+ArrayInputSection.propTypes = {
+  label: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
+  register: PropTypes.func.isRequired,
+  errors: PropTypes.object.isRequired,
+  validate: PropTypes.func,
+  isProcessing: PropTypes.bool,
+  placeholder: PropTypes.string,
+};
+
+export default ArrayInputSection;

--- a/client/src/components/UserPersonalProfile/Shared/SettingsSections/DeleteAccountButton.jsx
+++ b/client/src/components/UserPersonalProfile/Shared/SettingsSections/DeleteAccountButton.jsx
@@ -1,0 +1,122 @@
+import { useState } from "react";
+import PropTypes from "prop-types";
+import styles from "../settings.module.css";
+
+export default function DeleteAccountButton({
+  userEmail,
+  onDelete,
+  isProcessing,
+}) {
+  const [showModal, setShowModal] = useState(false);
+  const [inputEmail, setInputEmail] = useState("");
+  const [error, setError] = useState("");
+
+  const handleOpen = () => {
+    setShowModal(true);
+    setInputEmail("");
+    setError("");
+  };
+
+  const handleClose = () => {
+    setShowModal(false);
+    setInputEmail("");
+    setError("");
+  };
+
+  const handleConfirm = () => {
+    if (inputEmail.trim() !== userEmail) {
+      setError("Email does not match.");
+      return;
+    }
+    setError("");
+    onDelete();
+    setShowModal(false);
+  };
+
+  return (
+    <>
+      <button
+        type="button"
+        className="btn btn-primary"
+        // override styles for the button
+        style={{
+          background: "#e11d48",
+          color: "#fff",
+          border: "none",
+          minWidth: 80,
+          maxWidth: 200,
+          padding: "0.3rem 0.5rem",
+          fontWeight: 500,
+          fontSize: "1rem",
+        }}
+        onClick={handleOpen}
+        disabled={isProcessing}
+      >
+        Delete Account
+      </button>
+      {showModal && (
+        <div className={styles.modalOverlay}>
+          <div className={styles.modalContent}>
+            <h3>Confirm Account Deletion</h3>
+            <p>
+              Please enter your email (<b>{userEmail}</b>) to confirm account
+              deletion.
+              <br />
+              <span style={{ color: "var(--error-color, #e11d48)" }}>
+                This action cannot be undone!
+              </span>
+            </p>
+            <input
+              type="email"
+              className={styles.inputField}
+              placeholder="Enter your email"
+              value={inputEmail}
+              onChange={(e) => setInputEmail(e.target.value)}
+              disabled={isProcessing}
+            />
+            {error && <p className={styles.errorText}>{error}</p>}
+            <div className={styles.modalActions}>
+              <button
+                type="button"
+                className="btn btn-primary"
+                style={{
+                  background: "#e11d48",
+                  color: "#fff",
+                  border: "none",
+                  minWidth: 80,
+                  padding: "0.2rem 0.3rem",
+                  fontWeight: 500,
+                  fontSize: "0.96rem",
+                }}
+                onClick={handleConfirm}
+                disabled={isProcessing}
+              >
+                Delete
+              </button>
+              <button
+                type="button"
+                className="btn btn-secondary"
+                style={{
+                  minWidth: 80,
+                  padding: "0.2rem 0.3rem",
+                  fontWeight: 500,
+                  fontSize: "0.9rem",
+                }}
+                onClick={handleClose}
+                disabled={isProcessing}
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}
+
+DeleteAccountButton.propTypes = {
+  userEmail: PropTypes.string.isRequired,
+  onDelete: PropTypes.func.isRequired,
+  isProcessing: PropTypes.bool,
+};

--- a/client/src/components/UserPersonalProfile/Shared/SettingsSections/EmailLocationPassword.jsx
+++ b/client/src/components/UserPersonalProfile/Shared/SettingsSections/EmailLocationPassword.jsx
@@ -1,0 +1,89 @@
+import styles from "../settings.module.css";
+import PropTypes from "prop-types";
+
+const EmailLocationPassword = ({
+  register,
+  errors,
+  watch,
+  isProcessing,
+  showLocation = true,
+}) => (
+  <div className={styles.sectionContainer}>
+    <div className={styles.formField}>
+      <label htmlFor="email">Email:</label>
+      <input
+        className={`input-field${errors.email ? " input-error" : ""}`}
+        id="email"
+        type="email"
+        disabled={isProcessing}
+        {...register("email", {
+          required: "Email is required",
+          pattern: {
+            value: /^[^\s@]+@[^\s@]+\.[^\s@]+$/,
+            message: "Please enter a valid email address",
+          },
+        })}
+      />
+      {errors.email && (
+        <p className={styles.errorText}>{errors.email.message}</p>
+      )}
+    </div>
+    {showLocation && (
+      <div className={styles.formField}>
+        <label htmlFor="location">Location:</label>
+        <input
+          className="input-field"
+          id="location"
+          type="text"
+          disabled={isProcessing}
+          {...register("location")}
+        />
+      </div>
+    )}
+    <div className={styles.formField}>
+      <label htmlFor="password">Password:</label>
+      <input
+        className={`input-field${errors.password ? " input-error" : ""}`}
+        id="password"
+        type="password"
+        disabled={isProcessing}
+        {...register("password", {
+          minLength: {
+            value: 8,
+            message: "Password must be at least 8 characters",
+          },
+        })}
+      />
+      {errors.password && (
+        <p className={styles.errorText}>{errors.password.message}</p>
+      )}
+    </div>
+    <div className={styles.formField}>
+      <label htmlFor="confirmPassword">Confirm Password:</label>
+      <input
+        className={`input-field${errors.confirmPassword ? " input-error" : ""}`}
+        id="confirmPassword"
+        type="password"
+        disabled={isProcessing}
+        {...register("confirmPassword", {
+          validate: (value) =>
+            !watch("password") ||
+            value === watch("password") ||
+            "Passwords do not match",
+        })}
+      />
+      {errors.confirmPassword && (
+        <p className={styles.errorText}>{errors.confirmPassword.message}</p>
+      )}
+    </div>
+  </div>
+);
+
+EmailLocationPassword.propTypes = {
+  register: PropTypes.func.isRequired,
+  errors: PropTypes.object.isRequired,
+  watch: PropTypes.func.isRequired,
+  isProcessing: PropTypes.bool.isRequired,
+  showLocation: PropTypes.bool,
+};
+export default EmailLocationPassword;

--- a/client/src/components/UserPersonalProfile/Shared/SettingsSections/FeedbackMessage.jsx
+++ b/client/src/components/UserPersonalProfile/Shared/SettingsSections/FeedbackMessage.jsx
@@ -1,0 +1,28 @@
+import PropTypes from "prop-types";
+const FeedbackMessage = ({ feedback, uploadError }) => {
+  if (!feedback && !uploadError) return null;
+
+  return (
+    <div className="toastMessageWrapper">
+      {feedback && (
+        <div
+          className={`toastMessage ${
+            feedback.includes("success") ? "toastSuccess" : "toastWarning"
+          }`}
+        >
+          {feedback}
+        </div>
+      )}
+      {uploadError && (
+        <div className="toastMessage toastError">{uploadError}</div>
+      )}
+    </div>
+  );
+};
+
+FeedbackMessage.propTypes = {
+  feedback: PropTypes.string,
+  uploadError: PropTypes.string,
+};
+
+export default FeedbackMessage;

--- a/client/src/components/UserPersonalProfile/Shared/SettingsSections/ProfilePhotoSection.jsx
+++ b/client/src/components/UserPersonalProfile/Shared/SettingsSections/ProfilePhotoSection.jsx
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import { useState } from "react";
 import { useUser } from "../../../../contexts/UserContext";
 import { Controller } from "react-hook-form";
-import { MdDelete } from "react-icons/md";
+import { MdDelete, MdUpload } from "react-icons/md";
 import styles from "../settings.module.css";
 
 export default function ProfilePhotoSection({
@@ -52,7 +52,13 @@ export default function ProfilePhotoSection({
           <div className={styles.photoPlaceholder}>No Photo</div>
         )}
       </div>
-
+      <label
+        htmlFor="profilePhoto"
+        className={styles.uploadBtn}
+        title="Upload Photo"
+      >
+        <MdUpload size={22} style={{ verticalAlign: "middle" }} />
+      </label>
       <Controller
         control={control}
         name="profilePhoto"
@@ -64,6 +70,8 @@ export default function ProfilePhotoSection({
             onChange={(e) => onChange(e.target.files)}
             ref={ref}
             disabled={isProcessing}
+            // This input is hidden, the label acts as the button
+            style={{ display: "none" }}
           />
         )}
       />

--- a/client/src/components/UserPersonalProfile/Shared/SettingsSections/ProfilePhotoSection.jsx
+++ b/client/src/components/UserPersonalProfile/Shared/SettingsSections/ProfilePhotoSection.jsx
@@ -1,0 +1,82 @@
+import PropTypes from "prop-types";
+
+import { useState } from "react";
+import { useUser } from "../../../../contexts/UserContext";
+import { Controller } from "react-hook-form";
+import { MdDelete } from "react-icons/md";
+import styles from "../settings.module.css";
+
+export default function ProfilePhotoSection({
+  profilePhotoUrl,
+  control,
+  errors,
+  isProcessing,
+}) {
+  const { updateProfile } = useUser();
+  const [deleteError, setDeleteError] = useState("");
+
+  const handleDelete = async () => {
+    setDeleteError("");
+    try {
+      await updateProfile({ profilePhoto: "" });
+    } catch {
+      setDeleteError("Failed to delete photo");
+    }
+  };
+
+  return (
+    <div className={styles.settingsPhotoSection}>
+      <label>Profile Photo</label>
+      <div
+        className={styles.settingsPhotoPreview}
+        style={{ position: "relative" }}
+      >
+        {profilePhotoUrl ? (
+          <>
+            <img
+              src={profilePhotoUrl}
+              alt="Current"
+              className={styles.photoPreviewImage}
+            />
+            <button
+              type="button"
+              onClick={handleDelete}
+              className={styles.deletePhotoButton}
+              disabled={isProcessing}
+              title="Remove photo"
+            >
+              <MdDelete />
+            </button>
+          </>
+        ) : (
+          <div className={styles.photoPlaceholder}>No Photo</div>
+        )}
+      </div>
+
+      <Controller
+        control={control}
+        name="profilePhoto"
+        render={({ field: { onChange, ref } }) => (
+          <input
+            id="profilePhoto"
+            type="file"
+            accept="image/*"
+            onChange={(e) => onChange(e.target.files)}
+            ref={ref}
+            disabled={isProcessing}
+          />
+        )}
+      />
+      {errors.profilePhoto && (
+        <p className={styles.errorText}>{errors.profilePhoto.message}</p>
+      )}
+      {deleteError && <p className={styles.errorText}>{deleteError}</p>}
+    </div>
+  );
+}
+ProfilePhotoSection.propTypes = {
+  profilePhotoUrl: PropTypes.string,
+  control: PropTypes.object.isRequired,
+  errors: PropTypes.object.isRequired,
+  isProcessing: PropTypes.bool.isRequired,
+};

--- a/client/src/components/UserPersonalProfile/Shared/settings.module.css
+++ b/client/src/components/UserPersonalProfile/Shared/settings.module.css
@@ -149,12 +149,6 @@ input[type="file"] {
   cursor: not-allowed;
 }
 
-.dynamicFieldGroup {
-  border-bottom: 1px solid #e5e7eb;
-  padding-bottom: 1rem;
-  margin-bottom: 1rem;
-}
-
 .dynamicFieldGroup:last-child {
   border-bottom: none;
   margin-bottom: 0;

--- a/client/src/components/UserPersonalProfile/Shared/settings.module.css
+++ b/client/src/components/UserPersonalProfile/Shared/settings.module.css
@@ -1,0 +1,378 @@
+.settingsWrapper {
+  max-width: 900px;
+  margin: 2rem 0 2rem 3vw;
+  padding: 1.2rem 1rem 2rem 1rem;
+  border-radius: var(--default-xl-border-radius, 12px);
+  box-shadow: 0 2px 16px 0 rgba(0, 0, 0, 0.04);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.settingsTitle {
+  font-size: 1.5rem;
+  font-weight: var(--font-weight-bold, 700);
+  margin-bottom: 1rem;
+  font-family: var(--heading-font-family, "Outfit", sans-serif);
+  color: var(--primary-color, #4f46e5);
+}
+
+.settingsPhotoSection,
+.resumeSection {
+  margin-bottom: 1rem;
+}
+
+.settingsPhotoPreview {
+  width: 90px;
+  height: 90px;
+  margin-bottom: 0.7rem;
+  border-radius: 50%;
+  overflow: hidden;
+  background: var(--bg-color, #f3f4f6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.deletePhotoButton {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  background: rgba(255, 255, 255, 0.8);
+  color: var(--error-color, #e11d48);
+  border: none;
+  border-radius: 50%;
+  cursor: pointer;
+  padding: 0.3rem;
+  font-size: 1.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.photoPlaceholder {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-secondary-color, #888);
+  font-size: 1.1rem;
+  background: var(--border-color, #e5e7eb);
+}
+
+input[type="file"] {
+  width: auto;
+  max-width: 250px;
+  display: inline-block;
+  padding: 0.2rem 0.3rem;
+  font-size: 1rem;
+  background: var(--surface-color, #fff);
+  border-radius: var(--default-sm-border-radius, 6px);
+  border: 1px solid var(--border-color, #e5e7eb);
+}
+
+.settingsForm {
+  width: 100%;
+  margin-top: 0.5rem;
+}
+.formGrid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.2rem;
+  width: 100%;
+  margin-bottom: 1.2rem;
+}
+
+.formGrid > div {
+  display: flex;
+  flex-direction: column;
+  gap: 0.7rem;
+}
+
+.expEduGrid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.2rem;
+  width: 100%;
+  margin-bottom: 1.2rem;
+}
+.sectionContainer {
+  background: transparent;
+  border: none;
+  border-radius: 0;
+  padding: 0;
+  margin-bottom: 1.2rem;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.formField {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  margin-bottom: 0.7rem;
+  width: 100%;
+}
+.formField textarea {
+  min-height: 80px;
+  margin-bottom: 1.1rem;
+}
+.errorText {
+  color: var(--error-color, #e11d48);
+  font-size: 1rem;
+  margin: 0 0 0.2rem 0;
+}
+
+.settingsDivider {
+  border: none;
+  border-top: 1.5px solid var(--border-color, #e5e7eb);
+  margin: 2rem 0 1.5rem 0;
+  width: 100%;
+}
+
+.settingsDeleteBtn {
+  background: var(--accent-color, #e11d48);
+  color: var(--btn-text-color, #fff);
+  border: none;
+  border-radius: var(--default-sm-border-radius, 8px);
+  padding: 0.7rem 1.5rem;
+  font-size: 1rem;
+  font-weight: var(--font-weight-semibold, 600);
+  cursor: pointer;
+  margin-top: 1.5rem;
+  transition: background 0.2s;
+}
+
+.settingsDeleteBtn:disabled {
+  background: var(--disabled-bg, #f3f4f6);
+  color: var(--disabled-text, #aaa);
+  cursor: not-allowed;
+}
+
+.dynamicFieldGroup {
+  border-bottom: 1px solid #e5e7eb;
+  padding-bottom: 1rem;
+  margin-bottom: 1rem;
+}
+
+.dynamicFieldGroup:last-child {
+  border-bottom: none;
+  margin-bottom: 0;
+  padding-bottom: 0;
+}
+.collapsibleHeader {
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 1rem;
+  background: #f3f4f6;
+  border-radius: 6px;
+  padding: 0.7rem 1rem;
+  margin-bottom: 0.5rem;
+  margin-top: 0.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  transition: background 0.2s;
+  border: 1px solid #e5e7eb;
+}
+
+.collapsibleHeader:hover {
+  background: #e0e7ff;
+}
+
+.arrowIcon {
+  font-size: 1.2rem;
+  margin-left: 1rem;
+  color: #4f46e5;
+  transition: transform 0.2s;
+  user-select: none;
+}
+
+.arrowOpen {
+  transform: rotate(180deg);
+}
+.removeBtn {
+  background: var(--error-color, #e11d48);
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  padding: 0.4rem 1.1rem;
+  font-size: 1rem;
+  margin-top: 0.7rem;
+  margin-bottom: 0.7rem;
+  cursor: pointer;
+  display: inline-block;
+  transition: background 0.2s;
+}
+
+.removeBtn:hover {
+  background: #be123c;
+}
+
+.addBtn {
+  background: var(--primary-color, #4f46e5);
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  padding: 0.5rem 1.3rem;
+  font-size: 1rem;
+  margin-top: 1rem;
+  margin-bottom: 1.2rem;
+  cursor: pointer;
+  display: inline-block;
+  font-weight: 600;
+  transition: background 0.2s;
+}
+
+.addBtn:hover {
+  background: #3730a3;
+}
+
+.feedbackMessageWrapper {
+  width: 100%;
+  margin-bottom: 1.2rem;
+  text-align: center;
+}
+
+.feedbackMessage {
+  font-size: 1.08rem;
+  font-weight: 500;
+  margin: 0.2rem 0;
+  padding: 0.5rem 0.8rem;
+  border-radius: 6px;
+  background: #f9fafb;
+  display: inline-block;
+}
+
+.dynamicFieldGroup {
+  border-bottom: 1px solid #e5e7eb;
+  padding-bottom: 0.7rem;
+  margin-bottom: 0.7rem;
+}
+
+.dynamicFieldGroup:last-child {
+  border-bottom: none;
+  margin-bottom: 0;
+  padding-bottom: 0;
+}
+
+input,
+.input-field,
+textarea {
+  font-size: 0.97rem;
+  padding: 0.28rem 0.5rem;
+}
+
+.companyFormGrid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.2rem 2rem;
+  margin-bottom: 2rem;
+}
+
+.cvActionsRow {
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+  margin-top: 0.2rem;
+}
+
+.viewCvBtn {
+  background: var(--primary-color, #4f46e5);
+  color: var(--btn-text-color, #fff);
+  border: none;
+  border-radius: var(--default-sm-border-radius, 6px);
+  padding: 0.35rem 1.1rem;
+  font-size: 1rem;
+  font-weight: 500;
+  text-decoration: none;
+  display: inline-block;
+  transition: background 0.2s;
+}
+
+.viewCvBtn:hover {
+  background: #3730a3;
+  color: #fff;
+}
+
+.deleteCvBtn {
+  background: rgba(255, 255, 255, 0.8);
+  color: var(--error-color, #e11d48);
+  border: none;
+  border-radius: 50%;
+  cursor: pointer;
+  padding: 0.3rem;
+  font-size: 1.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.2s;
+}
+
+.deleteCvBtn:hover {
+  background: #ffe4e6;
+  color: #be123c;
+}
+
+.updateBtn {
+  background: var(--secondary-color, #22c55e);
+  color: var(--btn-text-color, #fff);
+  border: none;
+  border-radius: 6px;
+  font-size: 1rem;
+  padding: 0.5rem 1.2rem;
+  font-weight: 600;
+  transition: background 0.2s;
+  cursor: pointer;
+}
+
+.updateBtn:hover {
+  background: #16a34a;
+}
+.uploadBtn {
+  background: var(--surface-color, #fff);
+  color: var(red, #222);
+  border: 1px solid var(--border-color, #e5e7eb);
+  border-radius: 6px;
+  padding: 0.4rem 1rem;
+  font-size: 1rem;
+  font-family: inherit;
+  margin-top: 0.3rem;
+  margin-bottom: 0.7rem;
+  cursor: pointer;
+  transition:
+    border 0.2s,
+    box-shadow 0.2s;
+}
+
+.uploadBtn:disabled {
+  background: var(--disabled-bg, #f3f4f6);
+  color: var(--disabled-text, #aaa);
+  cursor: not-allowed;
+}
+.hiddenInput {
+  display: none;
+}
+
+@media (max-width: 900px) {
+  .companyFormGrid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 900px) {
+  .settingsWrapper {
+    max-width: 99vw;
+    margin: 0.5rem;
+    padding: 0.7rem 0.2rem;
+  }
+  .formGrid {
+    grid-template-columns: 1fr;
+    gap: 1.2rem;
+  }
+
+  .settingsForm {
+    grid-template-columns: 1fr;
+    gap: 1rem;
+  }
+}

--- a/client/src/components/UserPersonalProfile/Shared/settings.module.css
+++ b/client/src/components/UserPersonalProfile/Shared/settings.module.css
@@ -323,29 +323,82 @@ textarea {
 .updateBtn:hover {
   background: #16a34a;
 }
+
 .uploadBtn {
-  background: var(--surface-color, #fff);
-  color: var(red, #222);
-  border: 1px solid var(--border-color, #e5e7eb);
-  border-radius: 6px;
-  padding: 0.4rem 1rem;
-  font-size: 1rem;
-  font-family: inherit;
-  margin-top: 0.3rem;
-  margin-bottom: 0.7rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--secondary-color, #22c55e);
+  color: #fff;
+  border: none;
+  border-radius: 50%;
+  width: 38px;
+  height: 38px;
+  padding: 0;
+  margin-top: 0.2rem;
+  margin-bottom: 0.5rem;
   cursor: pointer;
+  font-size: 1.3rem;
+  box-shadow: 0 2px 8px 0 rgba(79, 70, 229, 0.08);
   transition:
-    border 0.2s,
-    box-shadow 0.2s;
+    background 0.2s,
+    box-shadow 0.2s,
+    color 0.2s;
+}
+
+.uploadBtn:hover,
+.uploadBtn:focus {
+  background: var(--hover-color, #16a34a);
+  color: var(--primary-color);
+  box-shadow: 0 4px 16px 0 rgba(79, 70, 229, 0.13);
+  outline: none;
 }
 
 .uploadBtn:disabled {
   background: var(--disabled-bg, #f3f4f6);
   color: var(--disabled-text, #aaa);
   cursor: not-allowed;
+  box-shadow: none;
 }
-.hiddenInput {
-  display: none;
+.fullWidthField {
+  grid-column: 1 / -1;
+  width: 100%;
+}
+
+/* Delete content */
+.modalOverlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.35);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+.modalContent {
+  background: #fff;
+  border-radius: 10px;
+  padding: 1.5rem 1.2rem 1.2rem 1.2rem;
+  box-shadow: 0 4px 32px 0 rgba(0, 0, 0, 0.18);
+  max-width: 340px;
+  width: 100%;
+  text-align: center;
+}
+.inputField {
+  width: 100%;
+  padding: 0.5rem;
+  margin-top: 1rem;
+  margin-bottom: 0.5rem;
+  font-size: 1rem;
+  border-radius: 6px;
+  border: 1px solid #e5e7eb;
+}
+
+.modalActions {
+  display: flex;
+  justify-content: center;
+  gap: 0.7rem;
+  margin-top: 1.1rem;
 }
 
 @media (max-width: 900px) {

--- a/client/src/contexts/UserContext.jsx
+++ b/client/src/contexts/UserContext.jsx
@@ -59,6 +59,14 @@ export function UserProvider({ children }) {
     await userService.logout();
     setUser(null);
   };
+
+  // delete account function
+
+  const deleteAccount = async () => {
+    await userService.deleteAccount();
+    setUser(null);
+  };
+
   // update profile function
   const updateProfile = async (data) => {
     const updated = await userService.updateProfile(data);
@@ -74,6 +82,7 @@ export function UserProvider({ children }) {
         login,
         logout,
         updateProfile,
+        deleteAccount,
       }}
     >
       {children}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -218,3 +218,141 @@ body {
   transform: scale(1.06) rotate(-2deg);
   cursor: pointer;
 }
+
+/* --------Input Field Styles------------ */
+.input-field {
+  width: 100%;
+  max-width: 400px;
+  padding: 0.6rem 1rem;
+  font-size: 1rem;
+  font-family: var(--text-font-family, inherit);
+  color: var(--text-color, #222);
+  background: var(--surface-color, #fff);
+  border: 1.5px solid var(--border-color, #ccc);
+  border-radius: var(--default-sm-border-radius, 8px);
+  outline: none;
+  transition:
+    border-color 0.2s,
+    box-shadow 0.2s;
+  margin-top: 0.25rem;
+  margin-bottom: 1rem;
+  box-sizing: border-box;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.03);
+}
+
+.input-field:focus {
+  border-color: var(--primary-color, #007bff);
+  box-shadow: 0 0 0 2px var(--hover-color, #e3f0ff);
+}
+
+.input-field[disabled] {
+  background-color: var(--disabled-bg, #f5f5f5);
+  color: var(--disabled-text, #aaa);
+  cursor: not-allowed;
+}
+
+label {
+  font-weight: 500;
+  margin-bottom: 0.2rem;
+  display: block;
+  color: var(--primary-color, #007bff);
+}
+
+.input-field.input-error {
+  border-color: var(--error-color, #e53e3e) !important;
+  background-color: #fff5f5;
+  box-shadow: 0 0 0 2px rgba(229, 62, 62, 0.08);
+}
+
+@media (max-width: 600px) {
+  .input-field {
+    max-width: 100%;
+    font-size: 0.98rem;
+    padding: 0.5rem 0.7rem;
+  }
+}
+
+/* Toast Messages */
+.toastMessageWrapper {
+  position: fixed;
+  top: 2.5rem;
+  right: 2.5rem;
+  z-index: 9999;
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+  pointer-events: none;
+}
+
+.toastMessage {
+  min-width: 240px;
+  max-width: 380px;
+  padding: 1.1rem 1.7rem;
+  border-radius: 14px;
+  color: var(--btn-text-color, #fff);
+  font-weight: 500;
+  font-size: 1.05rem;
+  box-shadow:
+    0 8px 32px 0 rgba(31, 38, 135, 0.18),
+    0 1.5px 6px rgba(0, 0, 0, 0.08);
+  backdrop-filter: blur(6px);
+  background: rgba(
+    34,
+    197,
+    94,
+    0.92
+  ); /* fallback, will be overridden by .toastSuccess etc */
+  border: 1.5px solid rgba(255, 255, 255, 0.18);
+  opacity: 0;
+  transform: translateY(-30px) scale(0.98);
+  animation:
+    toastSlideIn 0.5s cubic-bezier(0.4, 2, 0.6, 1) forwards,
+    toastFadeOut 0.5s 2.5s cubic-bezier(0.4, 2, 0.6, 1) forwards;
+  pointer-events: all;
+  transition:
+    box-shadow 0.2s,
+    transform 0.2s;
+}
+
+@keyframes toastSlideIn {
+  from {
+    opacity: 0;
+    transform: translateY(-30px) scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+@keyframes toastFadeOut {
+  from {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+  to {
+    opacity: 0;
+    transform: translateY(-10px) scale(0.97);
+  }
+}
+
+.toastSuccess {
+  background: linear-gradient(
+    120deg,
+    var(--success-color, #22c55e) 80%,
+    #38a169 100%
+  );
+}
+.toastWarning {
+  background: linear-gradient(
+    120deg,
+    var(--warning-color, #f59e42) 80%,
+    #f6ad55 100%
+  );
+}
+.toastError {
+  background: linear-gradient(
+    120deg,
+    var(--error-color, #ef4444) 80%,
+    #e53e3e 100%
+  );
+}

--- a/client/src/util/arrayFromString.js
+++ b/client/src/util/arrayFromString.js
@@ -1,0 +1,10 @@
+// this function converts a comma-separated string into an array of strings
+
+export function arrayFromString(str) {
+  return str
+    ? str
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean)
+    : [];
+}

--- a/client/src/util/cloudinaryUpload.js
+++ b/client/src/util/cloudinaryUpload.js
@@ -13,10 +13,25 @@ export async function uploadFileToCloudinary(file) {
       method: "POST",
       body: formData,
     });
-    const data = await res.json();
+
+    let data;
+    try {
+      data = await res.json();
+    } catch {
+      data = {};
+    }
+    console.log("Cloudinary response:", data);
+
+    if (!res.ok) {
+      // check Cloudinary's error message if available
+      const message =
+        data.error?.message || `HTTP error! status: ${res.status}`;
+      throw new Error(message);
+    }
     if (data.error) {
       throw new Error(data.error.message);
     }
+
     return data.secure_url;
   } catch (err) {
     throw new Error(`Uploading failed: ${err.message}`);

--- a/client/src/util/cloudinaryUpload.js
+++ b/client/src/util/cloudinaryUpload.js
@@ -1,0 +1,24 @@
+// we will use cloudinary to upload images, and we will use the upload preset and cloud name from the environment variables, we wont use sigened upload for now.
+export async function uploadFileToCloudinary(file) {
+  const cloudName = import.meta.env.VITE_CLOUD_NAME;
+  const uploadPreset = import.meta.env.VITE_UPLOAD_PRESET;
+  const url = `https://api.cloudinary.com/v1_1/${cloudName}/auto/upload`;
+
+  const formData = new FormData();
+  formData.append("upload_preset", uploadPreset);
+  formData.append("file", file);
+
+  try {
+    const res = await fetch(url, {
+      method: "POST",
+      body: formData,
+    });
+    const data = await res.json();
+    if (data.error) {
+      throw new Error(data.error.message);
+    }
+    return data.secure_url;
+  } catch (err) {
+    throw new Error(`Uploading failed: ${err.message}`);
+  }
+}

--- a/server/src/controllers/user.js
+++ b/server/src/controllers/user.js
@@ -178,3 +178,23 @@ export async function logout(req, res) {
     });
   }
 }
+
+// Deletes a user account by ID.
+export async function deleteAccount(req, res) {
+  try {
+    const userId = req.user.id;
+    const user = await User.findById(userId);
+    if (!user) {
+      return res.status(404).json({ success: false, msg: "User not found." });
+    }
+    await user.deleteOne();
+    res.clearCookie("token");
+    return res.json({ success: true, msg: "Account deleted successfully." });
+  } catch (err) {
+    logError(err);
+    return res.status(500).json({
+      success: false,
+      msg: "Unable to delete account, please try again later.",
+    });
+  }
+}

--- a/server/src/routes/user.js
+++ b/server/src/routes/user.js
@@ -3,8 +3,8 @@ import {
   validateRegistration,
   validateLogin,
 } from "../middlewares/validateInput.js";
-import { login, register, logout } from "../controllers/user.js";
-
+import { login, register, logout, deleteAccount } from "../controllers/user.js";
+import authMiddleware from "../middlewares/authMiddleware.js";
 // ----- In this route we do the users auth actions, register, login and logout (the rest will be in profile route)
 
 const userRouter = express.Router();
@@ -12,5 +12,6 @@ const userRouter = express.Router();
 userRouter.post("/register", validateRegistration, register);
 userRouter.post("/login", validateLogin, login);
 userRouter.post("/logout", logout);
+userRouter.post("/delete", authMiddleware, deleteAccount);
 
 export default userRouter;


### PR DESCRIPTION
Created the Settings page for both. Seeker and company both have their own forms but with shared components for the possible fields.

-The user can view themselves as public mode. 

-The user can edit or delete their data with nested fields and date support, and it is frontend validated before a request to the API, ensuring the validations match the backend requirements. 

- User won't be able to update to invalid credentials or names.

- User will see input input-related message if the inputs are invalid with red styles.
- 
-User will see a toast message after the click on the update button to give him feedback. 

-Deleting the CV/photos options.

-For the files we used here a third party to store our files and store only the URLs for the database efficiency.

To run it locally, you need the env variables. Check Slack later.  

<img width="1196" alt="Screenshot 2025-05-30 at 21 59 16" src="https://github.com/user-attachments/assets/d139d9bd-230b-4235-8476-520d1cc0ad06" />
<img width="1224" alt="Screenshot 2025-05-30 at 21 59 26" src="https://github.com/user-attachments/assets/b1946772-edbb-41e7-b88c-9e341b8161dd" />
