### PR TITLE
Created Similar jobs component

### DIFF
--- a/client/src/components/JobDetail/EmployerInfo/AccordionSection.jsx
+++ b/client/src/components/JobDetail/EmployerInfo/AccordionSection.jsx
@@ -1,0 +1,38 @@
+import PropTypes from "prop-types";
+import {
+  Accordion,
+  AccordionSummary,
+  AccordionDetails,
+  Typography,
+} from "@mui/material";
+import { ExpandMore } from "@mui/icons-material";
+
+const AccordionSection = ({
+  icon: Icon,
+  title,
+  children,
+  styles,
+  defaultExpanded = false,
+}) => (
+  <Accordion defaultExpanded={defaultExpanded}>
+    <AccordionSummary expandIcon={<ExpandMore />}>
+      <Typography className={styles.accordionHeader}>
+        <Icon className={styles.statIcon} />
+        <span className={styles.sectionTitle}>{title}</span>
+      </Typography>
+    </AccordionSummary>
+    <AccordionDetails className={styles.accordionContent}>
+      {children}
+    </AccordionDetails>
+  </Accordion>
+);
+
+AccordionSection.propTypes = {
+  icon: PropTypes.elementType.isRequired,
+  title: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired,
+  styles: PropTypes.object.isRequired,
+  defaultExpanded: PropTypes.bool,
+};
+
+export default AccordionSection;

--- a/client/src/components/JobDetail/EmployerInfo/CompanyInfo.jsx
+++ b/client/src/components/JobDetail/EmployerInfo/CompanyInfo.jsx
@@ -1,0 +1,39 @@
+import PropTypes from "prop-types";
+import { MdLocationOn, MdEmail } from "react-icons/md";
+
+const CompanyInfo = ({ companyProfile, location, styles }) => (
+  <>
+    <p className={styles.companyName}>
+      {companyProfile?.companyName || "Unknown Company"}
+    </p>
+    <div className={styles.detailLine}>
+      <MdLocationOn className={styles.statIcon} />
+      <span>{location || "NA"}</span>
+    </div>
+    {companyProfile?.email && (
+      <div className={styles.detailLine}>
+        <MdEmail className={styles.statIcon} />
+        <span>{companyProfile.email}</span>
+      </div>
+    )}
+    <p className={styles.sectionTitle}>About Company</p>
+    <span>{companyProfile?.about || "No company description available."}</span>
+  </>
+);
+
+CompanyInfo.propTypes = {
+  companyProfile: PropTypes.shape({
+    companyName: PropTypes.string,
+    email: PropTypes.string,
+    about: PropTypes.string,
+  }),
+  location: PropTypes.string,
+  styles: PropTypes.object.isRequired,
+};
+
+CompanyInfo.defaultProps = {
+  companyProfile: {},
+  location: "NA",
+};
+
+export default CompanyInfo;

--- a/client/src/components/JobDetail/EmployerInfo/DeadlineSection.jsx
+++ b/client/src/components/JobDetail/EmployerInfo/DeadlineSection.jsx
@@ -1,0 +1,27 @@
+import PropTypes from "prop-types";
+import { MdAccessTime } from "react-icons/md";
+import AccordionSection from "./AccordionSection";
+
+const DeadlineSection = ({ expireOn, styles }) => {
+  const formatDate = (isoDate) =>
+    isoDate
+      ? new Date(isoDate).toLocaleDateString(undefined, {
+          year: "numeric",
+          month: "long",
+          day: "numeric",
+        })
+      : "No deadline specified";
+
+  return (
+    <AccordionSection icon={MdAccessTime} title="Deadline" styles={styles}>
+      <p>{formatDate(expireOn)}</p>
+    </AccordionSection>
+  );
+};
+
+DeadlineSection.propTypes = {
+  expireOn: PropTypes.string,
+  styles: PropTypes.object.isRequired,
+};
+
+export default DeadlineSection;

--- a/client/src/components/JobDetail/EmployerInfo/JobAccordion.jsx
+++ b/client/src/components/JobDetail/EmployerInfo/JobAccordion.jsx
@@ -1,0 +1,81 @@
+import PropTypes from "prop-types";
+import { MdBusiness, MdDescription, MdListAlt, MdBuild } from "react-icons/md";
+
+import AccordionSection from "./AccordionSection";
+import CompanyInfo from "./CompanyInfo";
+import ListSection from "./ListSection";
+import DeadlineSection from "./DeadlineSection";
+
+const JobAccordion = ({ job, styles }) => {
+  const {
+    companyProfile,
+    location,
+    description,
+    requirements = [],
+    tags = [],
+    expireOn,
+  } = job;
+
+  return (
+    <div className={styles.accordionSection}>
+      <AccordionSection
+        icon={MdBusiness}
+        title="Company"
+        styles={styles}
+        defaultExpanded
+      >
+        <CompanyInfo
+          companyProfile={companyProfile}
+          location={location}
+          styles={styles}
+        />
+      </AccordionSection>
+
+      <AccordionSection
+        icon={MdDescription}
+        title="Job Description"
+        styles={styles}
+      >
+        <p>{description || "No job description available."}</p>
+      </AccordionSection>
+
+      {requirements.length > 0 && (
+        <ListSection
+          icon={MdListAlt}
+          title="Requirements"
+          items={requirements}
+          styles={styles}
+        />
+      )}
+
+      {tags.length > 0 && (
+        <ListSection
+          icon={MdBuild}
+          title="Skills Required"
+          items={tags}
+          styles={styles}
+        />
+      )}
+
+      <DeadlineSection expireOn={expireOn} styles={styles} />
+    </div>
+  );
+};
+
+JobAccordion.propTypes = {
+  job: PropTypes.shape({
+    companyProfile: PropTypes.shape({
+      companyName: PropTypes.string,
+      email: PropTypes.string,
+      about: PropTypes.string,
+    }),
+    location: PropTypes.string,
+    description: PropTypes.string,
+    requirements: PropTypes.arrayOf(PropTypes.string),
+    tags: PropTypes.arrayOf(PropTypes.string),
+    expireOn: PropTypes.string,
+  }).isRequired,
+  styles: PropTypes.object.isRequired,
+};
+
+export default JobAccordion;

--- a/client/src/components/JobDetail/EmployerInfo/ListSection.jsx
+++ b/client/src/components/JobDetail/EmployerInfo/ListSection.jsx
@@ -5,8 +5,8 @@ import AccordionSection from "./AccordionSection";
 const ListSection = ({ icon, title, items, styles }) => (
   <AccordionSection icon={icon} title={title} styles={styles}>
     <ul className={styles.requirementsList}>
-      {items.map((item, i) => (
-        <li key={i} className={styles.requirementItem}>
+      {items.map((item) => (
+        <li key={item} className={styles.requirementItem}>
           <MdCheckCircle className={styles.requirementIcon} />
           {item}
         </li>

--- a/client/src/components/JobDetail/EmployerInfo/ListSection.jsx
+++ b/client/src/components/JobDetail/EmployerInfo/ListSection.jsx
@@ -1,0 +1,25 @@
+import PropTypes from "prop-types";
+import { MdCheckCircle } from "react-icons/md";
+import AccordionSection from "./AccordionSection";
+
+const ListSection = ({ icon, title, items, styles }) => (
+  <AccordionSection icon={icon} title={title} styles={styles}>
+    <ul className={styles.requirementsList}>
+      {items.map((item, i) => (
+        <li key={i} className={styles.requirementItem}>
+          <MdCheckCircle className={styles.requirementIcon} />
+          {item}
+        </li>
+      ))}
+    </ul>
+  </AccordionSection>
+);
+
+ListSection.propTypes = {
+  icon: PropTypes.elementType.isRequired,
+  title: PropTypes.string.isRequired,
+  items: PropTypes.arrayOf(PropTypes.string).isRequired,
+  styles: PropTypes.object.isRequired,
+};
+
+export default ListSection;

--- a/client/src/components/JobDetail/EmployerInfo/ListSection.jsx
+++ b/client/src/components/JobDetail/EmployerInfo/ListSection.jsx
@@ -5,8 +5,8 @@ import AccordionSection from "./AccordionSection";
 const ListSection = ({ icon, title, items, styles }) => (
   <AccordionSection icon={icon} title={title} styles={styles}>
     <ul className={styles.requirementsList}>
-      {items.map((item) => (
-        <li key={item} className={styles.requirementItem}>
+      {items.map((item, index) => (
+        <li key={`${item}-${index}`} className={styles.requirementItem}>
           <MdCheckCircle className={styles.requirementIcon} />
           {item}
         </li>

--- a/client/src/components/JobDetail/SimilarJob/JobCard.jsx
+++ b/client/src/components/JobDetail/SimilarJob/JobCard.jsx
@@ -1,0 +1,95 @@
+import PropTypes from "prop-types";
+import { Link } from "react-router-dom";
+import { GoLocation } from "react-icons/go";
+import moment from "moment";
+
+/**
+ * JobCard component displays a summarized view of a job posting.
+ * It includes company logo, job title, location, brief description,
+ * job type, and the relative posted time.
+ * The entire card is wrapped with a Link to the detailed job page.
+ *
+ * @param {object} props - The component props
+ * @param {object} props.job - Job data object
+ * @param {object} props.styles - Styles object for CSS classes
+ */
+const JobCard = ({ job, styles }) => {
+  // Destructure relevant job properties for easier access
+  const {
+    id,
+    title,
+    location,
+    type,
+    createdAt,
+    companyProfile,
+    description,
+    profilePhoto,
+  } = job;
+
+  // Use profilePhoto or fallback to empty string (no image)
+  const companyLogo = profilePhoto || "";
+
+  // Safely get company name or fallback to empty string
+  const companyName = companyProfile?.companyName || "";
+
+  return (
+    // Wrap entire card with Link to job details page using job id
+    <Link to={`/jobs/${id}`} className={styles.jobCardLink}>
+      <div className={styles.jobCard}>
+        {/* Header containing company logo and job basic info */}
+        <div className={styles.jobCardHeader}>
+          {/* Render company logo only if it exists */}
+          {companyLogo && (
+            <img
+              src={companyLogo}
+              alt={companyName}
+              className={styles.companyLogo}
+            />
+          )}
+          <div className={styles.jobInfo}>
+            {/* Job title */}
+            <p className={styles.jobTitle}>{title}</p>
+            {/* Location with icon */}
+            <span className={styles.location}>
+              <GoLocation className={styles.locationIcon} />
+              {location}
+            </span>
+          </div>
+        </div>
+
+        {/* Job description truncated to 150 chars with ellipsis if longer */}
+        <p className={styles.jobDescription}>
+          {description.length > 150
+            ? description.slice(0, 150) + "..."
+            : description}
+        </p>
+
+        {/* Footer with job type and relative posted time */}
+        <div className={styles.jobFooter}>
+          <span className={styles.jobType}>{type}</span>
+          <span className={styles.postedTime}>
+            {moment(createdAt).fromNow()}
+          </span>
+        </div>
+      </div>
+    </Link>
+  );
+};
+
+JobCard.propTypes = {
+  job: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    title: PropTypes.string.isRequired,
+    location: PropTypes.string.isRequired,
+    type: PropTypes.string.isRequired,
+    createdAt: PropTypes.string.isRequired,
+    companyProfile: PropTypes.shape({
+      companyName: PropTypes.string,
+    }),
+    description: PropTypes.string.isRequired,
+    profilePhoto: PropTypes.string,
+  }).isRequired,
+  styles: PropTypes.object.isRequired,
+};
+
+export default JobCard;

--- a/client/src/components/JobDetail/SimilarJob/JobCard.jsx
+++ b/client/src/components/JobDetail/SimilarJob/JobCard.jsx
@@ -3,18 +3,7 @@ import { Link } from "react-router-dom";
 import { GoLocation } from "react-icons/go";
 import moment from "moment";
 
-/**
- * JobCard component displays a summarized view of a job posting.
- * It includes company logo, job title, location, brief description,
- * job type, and the relative posted time.
- * The entire card is wrapped with a Link to the detailed job page.
- *
- * @param {object} props - The component props
- * @param {object} props.job - Job data object
- * @param {object} props.styles - Styles object for CSS classes
- */
 const JobCard = ({ job, styles }) => {
-  // Destructure relevant job properties for easier access
   const {
     id,
     title,
@@ -26,19 +15,13 @@ const JobCard = ({ job, styles }) => {
     profilePhoto,
   } = job;
 
-  // Use profilePhoto or fallback to empty string (no image)
   const companyLogo = profilePhoto || "";
-
-  // Safely get company name or fallback to empty string
-  const companyName = companyProfile?.companyName || "";
+  const companyName = companyProfile || "";
 
   return (
-    // Wrap entire card with Link to job details page using job id
     <Link to={`/jobs/${id}`} className={styles.jobCardLink}>
       <div className={styles.jobCard}>
-        {/* Header containing company logo and job basic info */}
         <div className={styles.jobCardHeader}>
-          {/* Render company logo only if it exists */}
           {companyLogo && (
             <img
               src={companyLogo}
@@ -47,9 +30,7 @@ const JobCard = ({ job, styles }) => {
             />
           )}
           <div className={styles.jobInfo}>
-            {/* Job title */}
             <p className={styles.jobTitle}>{title}</p>
-            {/* Location with icon */}
             <span className={styles.location}>
               <GoLocation className={styles.locationIcon} />
               {location}
@@ -57,14 +38,12 @@ const JobCard = ({ job, styles }) => {
           </div>
         </div>
 
-        {/* Job description truncated to 150 chars with ellipsis if longer */}
         <p className={styles.jobDescription}>
           {description.length > 150
             ? description.slice(0, 150) + "..."
             : description}
         </p>
 
-        {/* Footer with job type and relative posted time */}
         <div className={styles.jobFooter}>
           <span className={styles.jobType}>{type}</span>
           <span className={styles.postedTime}>
@@ -83,9 +62,7 @@ JobCard.propTypes = {
     location: PropTypes.string.isRequired,
     type: PropTypes.string.isRequired,
     createdAt: PropTypes.string.isRequired,
-    companyProfile: PropTypes.shape({
-      companyName: PropTypes.string,
-    }),
+    companyProfile: PropTypes.string,
     description: PropTypes.string.isRequired,
     profilePhoto: PropTypes.string,
   }).isRequired,

--- a/client/src/components/JobDetail/SimilarJob/SimilarJobs.jsx
+++ b/client/src/components/JobDetail/SimilarJob/SimilarJobs.jsx
@@ -3,18 +3,20 @@ import JobCard from "./JobCard";
 import PropTypes from "prop-types";
 
 /**
- * SimilarJobs component renders a list of similar job postings.
- * - Shows first 3 jobs by default.
- * - Users can toggle between showing all jobs or only the first 3.
- * - Uses JobCard component for each job rendering.
- *
- * Props:
- * - jobs: array of job objects to display.
- * - styles: CSS module styles object for styling.
+ * Helper function to map job object to JobCard props shape
  */
+const mapJobToCardProps = (job) => ({
+  id: job.id,
+  title: job.jobTitle,
+  type: job.jobType,
+  description: job.detail?.map((detailItem) => detailItem.desc).join(" ") || "",
+  location: job.location,
+  company: job.company,
+  createdAt: job.createdAt,
+});
+
 const SimilarJobs = ({ jobs, styles }) => {
   const [showAll, setShowAll] = useState(false);
-  // Show all jobs if toggled, else show first 3
   const jobsToShow = showAll ? jobs : jobs.slice(0, 3);
 
   return (
@@ -22,12 +24,10 @@ const SimilarJobs = ({ jobs, styles }) => {
       <p className={styles.similarJobsTitle}>Similar Job Posts</p>
       <div className={styles.similarJobsList}>
         {jobsToShow.map((job) => (
-          // Use job.id as key for better uniqueness instead of index
-          <JobCard job={job} key={job.id} styles={styles} />
+          <JobCard job={mapJobToCardProps(job)} key={job.id} styles={styles} />
         ))}
       </div>
 
-      {/* Toggle buttons to show more or less */}
       {!showAll && jobs.length > 3 && (
         <button
           className={styles.showMoreButton}

--- a/client/src/components/JobDetail/SimilarJob/SimilarJobs.jsx
+++ b/client/src/components/JobDetail/SimilarJob/SimilarJobs.jsx
@@ -11,7 +11,8 @@ const mapJobToCardProps = (job) => ({
   type: job.jobType,
   description: job.detail?.map((detailItem) => detailItem.desc).join(" ") || "",
   location: job.location,
-  company: job.company,
+  companyProfile: job.company?.name || "",
+  profilePhoto: job.company?.profileUrl || "",
   createdAt: job.createdAt,
 });
 

--- a/client/src/components/JobDetail/SimilarJob/SimilarJobs.jsx
+++ b/client/src/components/JobDetail/SimilarJob/SimilarJobs.jsx
@@ -1,0 +1,66 @@
+import { useState } from "react";
+import JobCard from "./JobCard";
+import PropTypes from "prop-types";
+
+const SimilarJobs = ({ jobs, styles }) => {
+  const [showAll, setShowAll] = useState(false);
+  const jobsToShow = showAll ? jobs : jobs.slice(0, 3);
+
+  return (
+    <div className={styles.similarJobsSection}>
+      <p className={styles.similarJobsTitle}>Similar Job Posts</p>
+      <div className={styles.similarJobsList}>
+        {jobsToShow.map((job, index) => (
+          <JobCard job={job} key={index} styles={styles} />
+        ))}
+      </div>
+
+      {!showAll && jobs.length > 3 && (
+        <button
+          className={styles.showMoreButton}
+          onClick={() => setShowAll(true)}
+          aria-label="Show more similar jobs"
+        >
+          Show More
+        </button>
+      )}
+
+      {showAll && (
+        <button
+          className={styles.showMoreButton}
+          onClick={() => setShowAll(false)}
+          aria-label="Show fewer similar jobs"
+        >
+          Show Less
+        </button>
+      )}
+    </div>
+  );
+};
+
+SimilarJobs.propTypes = {
+  jobs: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string.isRequired,
+      jobTitle: PropTypes.string.isRequired,
+      location: PropTypes.string.isRequired,
+      jobType: PropTypes.string.isRequired,
+      createdAt: PropTypes.string.isRequired,
+      company: PropTypes.shape({
+        profileUrl: PropTypes.string,
+        name: PropTypes.string,
+      }),
+      detail: PropTypes.arrayOf(
+        PropTypes.shape({
+          desc: PropTypes.string,
+        }),
+      ),
+    }),
+  ).isRequired,
+  styles: PropTypes.object.isRequired,
+};
+
+export default SimilarJobs;
+// SimilarJobs.jsx
+// This component displays a list of similar job posts. It allows users to toggle between showing a limited number of jobs or all available jobs.
+// It uses the JobCard component to render each job and includes a button to show more or fewer jobs based on user interaction.

--- a/client/src/components/JobDetail/SimilarJob/SimilarJobs.jsx
+++ b/client/src/components/JobDetail/SimilarJob/SimilarJobs.jsx
@@ -2,19 +2,32 @@ import { useState } from "react";
 import JobCard from "./JobCard";
 import PropTypes from "prop-types";
 
+/**
+ * SimilarJobs component renders a list of similar job postings.
+ * - Shows first 3 jobs by default.
+ * - Users can toggle between showing all jobs or only the first 3.
+ * - Uses JobCard component for each job rendering.
+ *
+ * Props:
+ * - jobs: array of job objects to display.
+ * - styles: CSS module styles object for styling.
+ */
 const SimilarJobs = ({ jobs, styles }) => {
   const [showAll, setShowAll] = useState(false);
+  // Show all jobs if toggled, else show first 3
   const jobsToShow = showAll ? jobs : jobs.slice(0, 3);
 
   return (
     <div className={styles.similarJobsSection}>
       <p className={styles.similarJobsTitle}>Similar Job Posts</p>
       <div className={styles.similarJobsList}>
-        {jobsToShow.map((job, index) => (
-          <JobCard job={job} key={index} styles={styles} />
+        {jobsToShow.map((job) => (
+          // Use job.id as key for better uniqueness instead of index
+          <JobCard job={job} key={job.id} styles={styles} />
         ))}
       </div>
 
+      {/* Toggle buttons to show more or less */}
       {!showAll && jobs.length > 3 && (
         <button
           className={styles.showMoreButton}
@@ -61,6 +74,3 @@ SimilarJobs.propTypes = {
 };
 
 export default SimilarJobs;
-// SimilarJobs.jsx
-// This component displays a list of similar job posts. It allows users to toggle between showing a limited number of jobs or all available jobs.
-// It uses the JobCard component to render each job and includes a button to show more or fewer jobs based on user interaction.


### PR DESCRIPTION
Enhance SimilarJobs section with reusable JobCard component

- Created reusable `JobCard` component to display summarized job info Includes company logo, title, location, description, type, and post time
- Implemented `SimilarJobs` component displays first 3 jobs by default with toggle to show more/less
  - Integrates `JobCard` for individual job rendering
- Applied modular CSS styles and ensured clean structure