### PR TITLE
Improvement to profile based recommendation.

### DIFF
--- a/server/src/constants.js
+++ b/server/src/constants.js
@@ -15,7 +15,7 @@ export const MAX_NR_REQUIREMENTS = 10;
 export const MAX_POSTS_PER_DAY = 5;
 
 // The MIN_JOBS  represents a min number of jobs we want to collect
-export const MIN_JOBS = 4;
+export const MIN_JOBS = 10;
 export const MAX_RECOMMENDATION_JOBS = 18;
 export const MAX_NUM_JOBS = 100;
 

--- a/server/src/controllers/jobRecommendations.js
+++ b/server/src/controllers/jobRecommendations.js
@@ -2,7 +2,7 @@ import {
   profileBasedMatchingCriterion,
   getProfileBasedRecommendations,
 } from "../util/jobMatching/profileBased.js";
-import { MIN_JOBS } from "../constants.js";
+import { MAX_RECOMMENDATION_JOBS } from "../constants.js";
 import { getIndustryMatchedJobs } from "../util/jobMatching/recentViewed.js";
 
 import { getRandomJobs } from "../helpers/jobPostHelper.js";
@@ -45,20 +45,23 @@ export const recommendationsByRecentView = async (req, res) => {
 };
 
 /**
- * Fetches recommended jobs using a tiered matching strategy.
+ * This function recommends jobs to the user (job seeker) based on:
+ * - Their position
+ * - Or both position and location
  *
- * It always starts by looking for jobs that strictly match all the criteria.
- * If no results are found, it gradually relaxes the filters; first trying moderate,
- * then loose criteria.
+ * Each job in the result includes a `matchedBy` field indicating the match type:
+ * - "by-position"
+ * - or "by-position-and-location"
  *
- * If even the loose criteria don’t return any jobs, it falls back to a default query,
- * like fetching the most recent job posts.
+ * If the user has not completed their profile, fallback jobs are shown,
+ * along with the message:
+ * "Complete your profile to get better recommendations."
  *
- * This approach follows a progression from:
- * Strict -> Moderate -> Loose -> Fallback
- *
- * Further we can add match level to the response.
+ * If the profile is complete but no matching jobs are found,
+ * random jobs are returned with the message:
+ * "No matches found. Showing random jobs instead."
  */
+
 export const recommendationsByProfile = async (req, res) => {
   const user = req.fullUser;
   const criteriaList = profileBasedMatchingCriterion(user);
@@ -74,8 +77,10 @@ export const recommendationsByProfile = async (req, res) => {
     });
   }
 
-  const { jobs, matchLevels } =
-    await getProfileBasedRecommendations(criteriaList);
+  const { jobs } = await getProfileBasedRecommendations(
+    criteriaList,
+    MAX_RECOMMENDATION_JOBS,
+  );
 
   if (!jobs.length) {
     const fallback = await getRandomJobs();
@@ -89,8 +94,7 @@ export const recommendationsByProfile = async (req, res) => {
 
   return res.status(200).json({
     success: true,
-    data: jobs.slice(0, MIN_JOBS),
+    data: jobs.slice(0, MAX_RECOMMENDATION_JOBS),
     type: "profile-based",
-    matchLevel: matchLevels.join(", "),
   });
 };

--- a/server/src/helpers/jobPostHelper.js
+++ b/server/src/helpers/jobPostHelper.js
@@ -1,6 +1,7 @@
 import { MAX_RECOMMENDATION_JOBS } from "../constants.js";
 import JobPost from "../models/JobPost.js";
 import { escapeRegex } from "../util/utils.js";
+import mongoose from "mongoose";
 
 /**
  * A generic function that we can use to search job posts based on a given criteria
@@ -57,8 +58,6 @@ export const findJobs = async (
  * 3: Joins with the "users" collection to get details about who posted each job.
  * 4: Unwinds the joined user data to simplify the structure.
  */
-
-import mongoose from "mongoose";
 
 export const getRandomJobs = async (
   excludeId,

--- a/server/src/util/jobMatching/profileBased.js
+++ b/server/src/util/jobMatching/profileBased.js
@@ -1,12 +1,11 @@
 import { escapeRegex } from "../utils.js";
 import { findJobs } from "../../helpers/jobPostHelper.js";
-import { MIN_JOBS } from "../../constants.js";
 
 /**
  * Constructs an array of job matching criteria with strict and
  * moderate levels based on the user's(seeker) profile.
  *
- * The loose is removed because it's adding noise to the results.
+ *
  */
 export const profileBasedMatchingCriterion = (user) => {
   const {
@@ -30,78 +29,50 @@ export const profileBasedMatchingCriterion = (user) => {
     return [];
   }
 
-  // Partial match is supported so title and position do NOT have to be exactly same
-  const titleCondition = { title: new RegExp(escapeRegex(position), "i") };
-  const languageCondition = { languages: { $in: languages } };
-  // Jobs with only isActive = true are included
-  const baseConditions = [{ isActive: true }, languageCondition];
+  const words = position.split(" ").map(escapeRegex);
+  const titleCondition = { title: new RegExp(words.join("|"), "i") };
 
-  const strict = {
-    $and: [
-      ...baseConditions,
-      { location },
-      { tags: { $in: skills } },
-      { type: { $in: preferences } },
-      titleCondition,
-    ],
+  const byPositionAndLocation = {
+    $and: [{ isActive: true }, titleCondition, { location: location }],
   };
 
-  const moderate = {
-    $or: [
-      {
-        $and: [...baseConditions, { location }, { tags: { $in: skills } }],
-      },
-      {
-        $and: [
-          ...baseConditions,
-          { type: { $in: preferences } },
-          { tags: { $in: skills } },
-        ],
-      },
-      {
-        $and: [...baseConditions, { location }, titleCondition],
-      },
-    ],
+  const byPosition = {
+    $and: [{ isActive: true }, titleCondition],
   };
 
   return [
-    { type: "strict", value: strict },
-    { type: "moderate", value: moderate },
+    {
+      type: "by-position-and-location",
+      value: byPositionAndLocation,
+    },
+    { type: "by-position", value: byPosition },
   ];
 };
 
-export const getUniqueJobs = (jobs) => {
-  const map = new Map();
-  for (const job of jobs) {
-    map.set(job._id.toString(), job);
-  }
-  return Array.from(map.values());
-};
+export const getProfileBasedRecommendations = async (criteria, maxNumber) => {
+  const [byPositionAndLocation, byPosition] = criteria;
 
-export const getProfileBasedRecommendations = async (criteriaList) => {
-  let recommendedJobs = [];
-  let matchLevelsUsed = new Set();
+  const jobsByPosition = await findJobs(
+    byPosition.value,
+    "title tags type location description isActive createdAt",
+    "postedBy",
+    false,
+    { createdAt: -1 },
+    0,
+    maxNumber,
+  );
 
-  for (const criteria of criteriaList) {
-    const jobs = await findJobs(
-      criteria.value,
-      "title tags type location description isActive createdAt",
-      "postedBy",
-      false,
-      { createdAt: -1 },
-      0,
-      10,
-    );
+  const locationValue = byPositionAndLocation.value.$and.find(
+    (c) => c.location,
+  )?.location;
 
-    if (jobs.length) {
-      recommendedJobs.push(...jobs);
-      matchLevelsUsed.add(criteria.type);
-      if (recommendedJobs.length >= MIN_JOBS) break;
-    }
-  }
+  const jobs = jobsByPosition.map((job) => {
+    const matchedBy =
+      job.location === locationValue
+        ? "by-position-and-location"
+        : "by-position";
+    return { ...job, matchedBy };
+  });
 
-  return {
-    jobs: getUniqueJobs(recommendedJobs),
-    matchLevels: Array.from(matchLevelsUsed),
-  };
+  return { jobs };
 };

--- a/server/src/util/utils.js
+++ b/server/src/util/utils.js
@@ -27,3 +27,19 @@ export const endOfToday = () => new Date(new Date().setHours(23, 59, 59, 999));
 export const escapeRegex = (text) => {
   return text.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&");
 };
+
+/**
+ * Given an array of object like:
+ * array = [{id: "id1", title: "Nurse", location: "Utrecht"},
+ *          {id: "id2", title: "Developer", location: "Amsterdam"},
+ *          {id: "id1", title: "Nurse", location: "Utrecht"}]
+ *
+ * This function removes duplicates.
+ */
+export const getUniqueObjects = (array) => {
+  const map = new Map();
+  for (const obj of array) {
+    map.set(obj._id.toString(), obj);
+  }
+  return Array.from(map.values());
+};


### PR DESCRIPTION

This PR improves job recommendation logic for job seekers by:
Matching jobs based on `position, or position + location`

Adding a `matchedBy` field to each job` ("by-position" or "by-position-and-location")`

It also handles fallback cases:

If the user profile is incomplete -> show random jobs with the message:
"Complete your profile to get better recommendations."

If no matches are found despite a complete profile-> show random jobs with:
"No matches found. Showing random jobs instead."
![jobRecommendation](https://github.com/user-attachments/assets/b9ff2b5b-898e-4737-ba19-1add19d023e5)
![jobRecommedationWithNoProfile](https://github.com/user-attachments/assets/4613f940-dfc3-461d-be02-f591bdb25e1a)





