### PR TITLE
Add scheduler to run updateIsActiveStatus every hour at 0.

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -18,6 +18,7 @@
         "jsonwebtoken": "^9.0.2",
         "mongodb-memory-server": "^10.1.0",
         "mongoose": "^8.3.2",
+        "node-cron": "^4.1.0",
         "nodemailer": "^7.0.3",
         "socket.io": "^4.8.1"
       },
@@ -7668,6 +7669,15 @@
       "license": "MIT",
       "engines": {
         "node": "^18 || ^20 || >= 21"
+      }
+    },
+    "node_modules/node-cron": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-4.1.0.tgz",
+      "integrity": "sha512-OS+3ORu+h03/haS6Di8Qr7CrVs4YaKZZOynZwQpyPZDnR3tqRbwJmuP2gVR16JfhLgyNlloAV1VTrrWlRogCFA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/node-gyp-build": {

--- a/server/package.json
+++ b/server/package.json
@@ -45,6 +45,7 @@
     "jsonwebtoken": "^9.0.2",
     "mongodb-memory-server": "^10.1.0",
     "mongoose": "^8.3.2",
+    "node-cron": "^4.1.0",
     "nodemailer": "^7.0.3",
     "socket.io": "^4.8.1"
   }

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -8,7 +8,7 @@ import { logInfo, logError } from "./util/logging.js";
 import connectDB from "./db/connectDB.js";
 import testRouter from "./testRouter.js";
 
-import { updateIsActiveStatus } from "./scripts/updateIsActive.js";
+import "./scripts/jobPostExpiration.js"; // starts the cron scheduler because the code runs as soon as the file is loaded.
 
 // socket.io imports
 import { Server } from "socket.io";
@@ -26,7 +26,6 @@ if (port == null) {
 const startServer = async () => {
   try {
     await connectDB();
-    await updateIsActiveStatus();
     // Create HTTP server and attach Socket.IO
     const server = http.createServer(app);
     const io = new Server(server, { cors: { origin: "*" } });

--- a/server/src/scripts/jobPostExpiration.js
+++ b/server/src/scripts/jobPostExpiration.js
@@ -36,6 +36,6 @@ cron.schedule("0 * * * *", async () => {
 
     await updateIsActiveStatus();
   } catch (error) {
-    logError("[corn] Error in updateIsJobActiveStatus");
+    logError("[corn] Error in updateIsActiveStatus");
   }
 });

--- a/server/src/scripts/jobPostExpiration.js
+++ b/server/src/scripts/jobPostExpiration.js
@@ -31,11 +31,11 @@ export const updateIsActiveStatus = async () => {
 cron.schedule("0 * * * *", async () => {
   try {
     logInfo(
-      `[corn] Running updateIsActiveStatus at ${new Date().toISOString()} `,
+      `[cron] Running updateIsActiveStatus at ${new Date().toISOString()} `,
     );
 
     await updateIsActiveStatus();
   } catch (error) {
-    logError("[corn] Error in updateIsActiveStatus");
+    logError("[cron] Error in updateIsActiveStatus");
   }
 });

--- a/server/src/scripts/jobPostExpiration.js
+++ b/server/src/scripts/jobPostExpiration.js
@@ -1,6 +1,11 @@
 import JobPost from "../models/JobPost.js";
 import { logError, logInfo } from "../util/logging.js";
+import cron from "node-cron";
 
+/**
+ * Deactivates job posts by setting `isActive` to false
+ * if their `expireOn` timestamp is in the past or now.
+ */
 export const updateIsActiveStatus = async () => {
   try {
     logInfo("Running updateIsActiveStatus");
@@ -18,3 +23,19 @@ export const updateIsActiveStatus = async () => {
     logError("Error updating job posts");
   }
 };
+
+/**
+ * Schedule a task i.e., updateIsActiveStatus
+ * and run it every hour at min 0
+ * */
+cron.schedule("0 * * * *", async () => {
+  try {
+    logInfo(
+      `[corn] Running updateIsActiveStatus at ${new Date().toISOString()} `,
+    );
+
+    await updateIsActiveStatus();
+  } catch (error) {
+    logError("[corn] Error in updateIsJobActiveStatus");
+  }
+});


### PR DESCRIPTION
Improved the job expiration update by scheduling `updateIsActiveStatus` with` node-cron`. Previously, the function was only called when the server restarted, which was unreliable. Now, it runs every hour at minute 0, checking the `expireOn` field and setting `isActive` to false for expired job posts.