### PR TITLE
 Change SocketIO to allow connections from any  origin

### DIFF
--- a/client/src/components/SocketManager/SocketManager.jsx
+++ b/client/src/components/SocketManager/SocketManager.jsx
@@ -27,7 +27,7 @@ const SocketManager = ({ children }) => {
       }
       return;
     }
-    console.log("Connecting", `${SERVER_URL}/notifications`);
+
     const nsSocket = io(`${SERVER_URL}/notifications`, {
       withCredentials: true,
       transports: ["websocket"],

--- a/server/src/socket.js
+++ b/server/src/socket.js
@@ -12,42 +12,8 @@ import { Server } from "socket.io";
 
 let io;
 
-const origin = process.env.FRONTEND_URL || "http://localhost:5173";
-
-/**
- * Initialize the Socket.IO server instance.
- *
- * It accepts one parameter which is the HTTP server.
- *
- * The initServer will attach this HTTP server instance to
- * Socket.IO which  allows both Socket.IO and HTTP server
- * to share same PORT.
- *
- * Please check the comments I put in index.js around 37
- *
- * Then it configs cors to allow connection from FE-React
- *
- * Also connection to this server can only happen if
- * credentials is true that means a user should login
- */
 export function initSocket(server) {
-  io = new Server(server, {
-    cors: {
-      origin: origin,
-      credentials: true,
-    },
-  });
-
-  // At this point, io is a Socket.IO Server object with
-  // many properties and methods:
-  //
-  // - io.on(event, callback): Listen for connection events, e.g. 'connection'
-  // - io.emit(event, data): Broadcast an event to all connected clients
-  // - io.to(room).emit(event, data): Emit to a specific room
-  //
-  // It manages all socket connections and allows real time
-  // bidirectional communication in our case notification handling
-  // You can find more about Socket.IO from here https://socket.io/docs/v4/
+  io = new Server(server, { cors: { origin: "*" } });
 }
 
 export function getIo() {


### PR DESCRIPTION
In the deployed version the notification socket was not connected, when I change it to `origin: "*"` it wored